### PR TITLE
Added DES connector

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
@@ -17,19 +17,33 @@
 package uk.gov.hmrc.lisaapi.connectors
 
 import uk.gov.hmrc.lisaapi.config.WSHttp
+import uk.gov.hmrc.lisaapi.controllers.JsonFormats
 import uk.gov.hmrc.lisaapi.models.CreateLisaInvestorRequest
 import uk.gov.hmrc.play.config.ServicesConfig
-import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost}
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost, HttpResponse}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-trait DesConnector extends ServicesConfig {
+trait DesConnector extends ServicesConfig with JsonFormats {
 
   val httpPost:HttpPost = WSHttp
   lazy val desUrl = baseUrl("des")
+  lazy val lisaServiceUrl = s"$desUrl/lisa"
 
   def createInvestor(lisaManager: String, request: CreateLisaInvestorRequest)(implicit hc: HeaderCarrier): Future[String] = {
-    ???
+    val uri = s"$lisaServiceUrl/$lisaManager"
+
+    val result = httpPost.POST[CreateLisaInvestorRequest, HttpResponse](uri, request)
+
+    result.map(r => {
+      r.status match {
+        case 201 => "Created"
+        case _ => "Error"
+      }
+    }).recover({
+      case _ => "Error"
+    })
   }
 
 }

--- a/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
@@ -14,22 +14,27 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.lisaapi.services
+package uk.gov.hmrc.lisaapi.connectors
 
-import uk.gov.hmrc.lisaapi.connectors.DesConnector
+import uk.gov.hmrc.lisaapi.config.WSHttp
 import uk.gov.hmrc.lisaapi.models.CreateLisaInvestorRequest
-import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost}
 
 import scala.concurrent.Future
 
-trait InvestorService  {
-  val desConnector: DesConnector
+trait DesConnector extends ServicesConfig {
 
-  def createInvestor(lisaManager: String, request: CreateLisaInvestorRequest)(implicit hc: HeaderCarrier) : Future[String] = {
-    desConnector.createInvestor(lisaManager, request)
+  val httpPost:HttpPost = WSHttp
+  lazy val desUrl = baseUrl("des")
+
+  def createInvestor(lisaManager: String, request: CreateLisaInvestorRequest)(implicit hc: HeaderCarrier): Future[String] = {
+    ???
   }
+
 }
 
-object InvestorService extends InvestorService {
-  override val desConnector: DesConnector = DesConnector
+
+object DesConnector extends DesConnector {
+
 }

--- a/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
@@ -31,18 +31,18 @@ trait DesConnector extends ServicesConfig with JsonFormats {
   lazy val desUrl = baseUrl("des")
   lazy val lisaServiceUrl = s"$desUrl/lisa"
 
-  def createInvestor(lisaManager: String, request: CreateLisaInvestorRequest)(implicit hc: HeaderCarrier): Future[String] = {
+  def createInvestor(lisaManager: String, request: CreateLisaInvestorRequest)(implicit hc: HeaderCarrier): Future[Either[String, String]] = {
     val uri = s"$lisaServiceUrl/$lisaManager"
 
     val result = httpPost.POST[CreateLisaInvestorRequest, HttpResponse](uri, request)
 
     result.map(r => {
       r.status match {
-        case 201 => "Created"
-        case _ => "Error"
+        case 201 => Right("Created")
+        case _ => Left("Error")
       }
     }).recover({
-      case _ => "Error"
+      case _ => Left("Error")
     })
   }
 

--- a/app/uk/gov/hmrc/lisaapi/controllers/InvestorController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/InvestorController.scala
@@ -36,7 +36,7 @@ class InvestorController extends LisaController {
     implicit request =>
       withValidJson[CreateLisaInvestorRequest] {
         createRequest => {
-          service.createInvestor(lisaManager).map { invest => Created(invest)
+          service.createInvestor(lisaManager, createRequest).map { invest => Created(invest)
           } recover {
             case _ => Status(ErrorInternalServerError.httpStatusCode)(Json.toJson(ErrorInternalServerError))
           }

--- a/app/uk/gov/hmrc/lisaapi/controllers/InvestorController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/InvestorController.scala
@@ -36,9 +36,11 @@ class InvestorController extends LisaController {
     implicit request =>
       withValidJson[CreateLisaInvestorRequest] {
         createRequest => {
-          service.createInvestor(lisaManager, createRequest).map { invest => Created(invest)
-          } recover {
-            case _ => Status(ErrorInternalServerError.httpStatusCode)(Json.toJson(ErrorInternalServerError))
+          service.createInvestor(lisaManager, createRequest).map { result =>
+            result match {
+              case Right(msg) => Created(Json.toJson(msg))
+              case Left(msg) => InternalServerError(Json.toJson(msg))
+            }
           }
         }
       }

--- a/app/uk/gov/hmrc/lisaapi/controllers/LisaController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/LisaController.scala
@@ -33,11 +33,6 @@ import scala.util.{Failure, Success, Try}
 trait LisaController extends BaseController with HeaderValidator with RunMode with JsonFormats {
   implicit val hc: HeaderCarrier
 
-  implicit def baseUrl(implicit request: Request[AnyContent]): String = env match {
-    case "Dev" => s"http://${request.headers.get(HeaderNames.HOST).getOrElse("unknown")}"
-    case _ => s"https://${AppContext.baseUrl}/${AppContext.apiContext}"
-  }
-
   protected def withValidJson[T](f: (T) => Future[Result])(implicit request: Request[AnyContent], reads: Reads[T]): Future[Result] =
     request.body.asJson match {
       case Some(json) =>

--- a/app/uk/gov/hmrc/lisaapi/services/InvestorService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/InvestorService.scala
@@ -25,7 +25,7 @@ import scala.concurrent.Future
 trait InvestorService  {
   val desConnector: DesConnector
 
-  def createInvestor(lisaManager: String, request: CreateLisaInvestorRequest)(implicit hc: HeaderCarrier) : Future[String] = {
+  def createInvestor(lisaManager: String, request: CreateLisaInvestorRequest)(implicit hc: HeaderCarrier) : Future[Either[String, String]] = {
     desConnector.createInvestor(lisaManager, request)
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -178,7 +178,7 @@ microservice {
         des {
             protocol = http
             host = localhost
-            port = 9000
+            port = 8883
             token = devToken
             serviceEnvironment = testEnv
         }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -172,3 +172,15 @@ wiremock-port = ${?WIREMOCK_PORT}
 
 Test.microservice.services.service-locator.host = "localhost"
 Test.microservice.services.service-locator.port = ${wiremock-port}
+
+microservice {
+    services {
+        des {
+            protocol = http
+            host = localhost
+            port = 9000
+            token = devToken
+            serviceEnvironment = testEnv
+        }
+    }
+}

--- a/test/unit/connectors/DesConnectorSpec.scala
+++ b/test/unit/connectors/DesConnectorSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.connectors
+
+import org.joda.time.DateTime
+import org.mockito.Matchers._
+import org.mockito.Mockito.when
+import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
+import uk.gov.hmrc.lisaapi.connectors.DesConnector
+import uk.gov.hmrc.lisaapi.models.CreateLisaInvestorRequest
+import uk.gov.hmrc.lisaapi.services.InvestorService
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost, HttpResponse, Upstream5xxResponse}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
+
+class DesConnectorSpec extends PlaySpec
+  with MockitoSugar
+  with OneAppPerSuite {
+
+  "DesConnector" must {
+
+    val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
+
+    "Return a Created Response" when {
+      "Given a 201 response from DES" in {
+        when(mockHttpPost.POST[CreateLisaInvestorRequest, HttpResponse](any(), any(), any())(any(), any(), any()))
+          .thenReturn(Future.successful(HttpResponse(201)))
+
+        val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
+        val result = Await.result(SUT.createInvestor("Z019283", request), Duration.Inf)
+
+        result must be("Created")
+      }
+    }
+
+    "Return a Error Response" when {
+      "Given a 500 response from DES" in {
+        when(mockHttpPost.POST[CreateLisaInvestorRequest, HttpResponse](any(), any(), any())(any(), any(), any()))
+          .thenReturn(Future.successful(HttpResponse(500)))
+
+        val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
+        val result = Await.result(SUT.createInvestor("Z019283", request), Duration.Inf)
+
+        result must be("Error")
+      }
+
+      "An upstream exception is thrown" ignore {
+        when(mockHttpPost.POST[CreateLisaInvestorRequest, HttpResponse](any(), any(), any())(any(), any(), any()))
+            .thenThrow(new RuntimeException("Upstream exceptions can be thrown by Http Verbs by default"))
+
+        val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
+        val result = Await.result(SUT.createInvestor("Z019283", request), Duration.Inf)
+
+        result must be("Error")
+      }
+    }
+
+  }
+
+  val mockHttpPost = mock[HttpPost]
+  implicit val hc = HeaderCarrier()
+
+  object SUT extends DesConnector {
+    override val httpPost = mockHttpPost
+  }
+}

--- a/test/unit/connectors/DesConnectorSpec.scala
+++ b/test/unit/connectors/DesConnectorSpec.scala
@@ -60,9 +60,9 @@ class DesConnectorSpec extends PlaySpec
         result must be("Error")
       }
 
-      "An upstream exception is thrown" ignore {
+      "An upstream exception is thrown" in {
         when(mockHttpPost.POST[CreateLisaInvestorRequest, HttpResponse](any(), any(), any())(any(), any(), any()))
-            .thenThrow(new RuntimeException("Upstream exceptions can be thrown by Http Verbs by default"))
+            .thenReturn(Future.failed(new RuntimeException("Http Verbs library can throw Upstream Exceptions")))
 
         val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
         val result = Await.result(SUT.createInvestor("Z019283", request), Duration.Inf)

--- a/test/unit/connectors/DesConnectorSpec.scala
+++ b/test/unit/connectors/DesConnectorSpec.scala
@@ -45,7 +45,7 @@ class DesConnectorSpec extends PlaySpec
         val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
         val result = Await.result(SUT.createInvestor("Z019283", request), Duration.Inf)
 
-        result must be("Created")
+        result must be(Right("Created"))
       }
     }
 
@@ -57,7 +57,7 @@ class DesConnectorSpec extends PlaySpec
         val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
         val result = Await.result(SUT.createInvestor("Z019283", request), Duration.Inf)
 
-        result must be("Error")
+        result must be(Left("Error"))
       }
 
       "An upstream exception is thrown" in {
@@ -67,7 +67,7 @@ class DesConnectorSpec extends PlaySpec
         val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
         val result = Await.result(SUT.createInvestor("Z019283", request), Duration.Inf)
 
-        result must be("Error")
+        result must be(Left("Error"))
       }
     }
 

--- a/test/unit/controllers/InvestorControllerSpec.scala
+++ b/test/unit/controllers/InvestorControllerSpec.scala
@@ -63,7 +63,7 @@ class InvestorControllerSpec extends WordSpec with MockitoSugar with ShouldMatch
   "The Investor Controller  " should {
     "return with status 200 createInvestor" in
       {
-        when(mockService.createInvestor(any())).thenReturn(Future.successful("result"))
+        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful("result"))
         val res = mockInvestorController.createLisaInvestor(lisaManager).apply(FakeRequest(Helpers.PUT,"/").withHeaders(acceptHeader).
           withBody(AnyContentAsJson(Json.parse(investorJson))))
         status(res) should be (CREATED)
@@ -71,7 +71,7 @@ class InvestorControllerSpec extends WordSpec with MockitoSugar with ShouldMatch
 
     "return with status 400 bad request" when {
       "given an invalid json body" in {
-        when(mockService.createInvestor(any())).thenReturn(Future.successful("result"))
+        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful("result"))
         val res = mockInvestorController.createLisaInvestor(lisaManager).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
           withBody(AnyContentAsJson(Json.parse(invalidInvestorJson))))
         status(res) should be(BAD_REQUEST)
@@ -81,7 +81,7 @@ class InvestorControllerSpec extends WordSpec with MockitoSugar with ShouldMatch
 
     "return with status 406 createInvestor " in
       {
-        when(mockService.createInvestor(any())).thenReturn(Future.successful("result"))
+        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful("result"))
         val res = mockInvestorController.createLisaInvestor(lisaManager).apply(FakeRequest(Helpers.PUT,"/").withHeaders(("accept","application/vnd.hmrc.2.0+json")))
         status(res) should be (406)
       }

--- a/test/unit/controllers/InvestorControllerSpec.scala
+++ b/test/unit/controllers/InvestorControllerSpec.scala
@@ -60,10 +60,10 @@ class InvestorControllerSpec extends WordSpec with MockitoSugar with ShouldMatch
 
   val lisaManager = "Z019283"
 
-  "The Investor Controller  " should {
+  "The Investor Controller" should {
     "return with status 200 createInvestor" in
       {
-        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful("result"))
+        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful(Right("Success")))
         val res = mockInvestorController.createLisaInvestor(lisaManager).apply(FakeRequest(Helpers.PUT,"/").withHeaders(acceptHeader).
           withBody(AnyContentAsJson(Json.parse(investorJson))))
         status(res) should be (CREATED)
@@ -71,17 +71,25 @@ class InvestorControllerSpec extends WordSpec with MockitoSugar with ShouldMatch
 
     "return with status 400 bad request" when {
       "given an invalid json body" in {
-        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful("result"))
+        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful(Right("Success")))
         val res = mockInvestorController.createLisaInvestor(lisaManager).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
           withBody(AnyContentAsJson(Json.parse(invalidInvestorJson))))
         status(res) should be(BAD_REQUEST)
       }
     }
 
+    "return with status 500 internal server error" when {
+      "given an invalid json body" in {
+        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful(Left("Error")))
+        val res = mockInvestorController.createLisaInvestor(lisaManager).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
+          withBody(AnyContentAsJson(Json.parse(investorJson))))
+        status(res) should be(INTERNAL_SERVER_ERROR)
+      }
+    }
 
     "return with status 406 createInvestor " in
       {
-        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful("result"))
+        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful(Right("Success")))
         val res = mockInvestorController.createLisaInvestor(lisaManager).apply(FakeRequest(Helpers.PUT,"/").withHeaders(("accept","application/vnd.hmrc.2.0+json")))
         status(res) should be (406)
       }

--- a/test/unit/controllers/InvestorControllerSpec.scala
+++ b/test/unit/controllers/InvestorControllerSpec.scala
@@ -70,10 +70,18 @@ class InvestorControllerSpec extends WordSpec with MockitoSugar with ShouldMatch
       }
 
     "return with status 400 bad request" when {
-      "given an invalid json body" in {
+      "given a json body which does not match the schema" in {
         when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful(Right("Success")))
         val res = mockInvestorController.createLisaInvestor(lisaManager).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
           withBody(AnyContentAsJson(Json.parse(invalidInvestorJson))))
+        status(res) should be(BAD_REQUEST)
+      }
+
+      "given a plain text body" in {
+        when(mockService.createInvestor(any(), any())(any())).thenReturn(Future.successful(Right("Success")))
+        val res = mockInvestorController.createLisaInvestor(lisaManager).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
+          withTextBody("hello"))
+
         status(res) should be(BAD_REQUEST)
       }
     }

--- a/test/unit/services/InvestorServiceSpec.scala
+++ b/test/unit/services/InvestorServiceSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.services
+
+import org.joda.time.DateTime
+import org.mockito.Matchers._
+import org.mockito.Mockito.when
+import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
+import uk.gov.hmrc.lisaapi.connectors.DesConnector
+import uk.gov.hmrc.lisaapi.models.CreateLisaInvestorRequest
+import uk.gov.hmrc.lisaapi.services.InvestorService
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
+
+class InvestorServiceSpec extends PlaySpec
+  with MockitoSugar
+  with OneAppPerSuite {
+
+  "InvestorService" must {
+
+    "Return a Created Response" when {
+
+      "Given a successful future from the DES connector" in {
+        when(mockDesConnector.createInvestor(any(), any())(any())).thenReturn(Future.successful("Created"))
+        val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
+
+        val result = Await.result(SUT.createInvestor("Z019283", request)(HeaderCarrier()), Duration.Inf)
+        result mustBe "Created"
+      }
+
+    }
+
+  }
+
+  val mockDesConnector = mock[DesConnector]
+  object TestInvestorService extends InvestorService {
+    override val desConnector: DesConnector = mockDesConnector
+  }
+
+  val SUT = TestInvestorService
+}

--- a/test/unit/services/InvestorServiceSpec.scala
+++ b/test/unit/services/InvestorServiceSpec.scala
@@ -50,9 +50,7 @@ class InvestorServiceSpec extends PlaySpec
   }
 
   val mockDesConnector = mock[DesConnector]
-  object TestInvestorService extends InvestorService {
+  object SUT extends InvestorService {
     override val desConnector: DesConnector = mockDesConnector
   }
-
-  val SUT = TestInvestorService
 }

--- a/test/unit/services/InvestorServiceSpec.scala
+++ b/test/unit/services/InvestorServiceSpec.scala
@@ -38,11 +38,11 @@ class InvestorServiceSpec extends PlaySpec
     "Return a Created Response" when {
 
       "Given a successful future from the DES connector" in {
-        when(mockDesConnector.createInvestor(any(), any())(any())).thenReturn(Future.successful("Created"))
+        when(mockDesConnector.createInvestor(any(), any())(any())).thenReturn(Future.successful(Right("Created")))
         val request = CreateLisaInvestorRequest("AB123456A", "A", "B", new DateTime("2000-01-01"))
 
         val result = Await.result(SUT.createInvestor("Z019283", request)(HeaderCarrier()), Duration.Inf)
-        result mustBe "Created"
+        result mustBe Right("Created")
       }
 
     }


### PR DESCRIPTION
Very barebones implementation - at the moment will only care about if it receives a 201 response or not and will return either "Created" or "Error".

Have deliberately left out more complex / contextual return types for now, and have left out auditing and metrics for the time being also.