### PR TITLE
Excluded dev package from coverage reports

### DIFF
--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -27,7 +27,7 @@ trait MicroService {
   lazy val scoverageSettings = {
     import ScoverageSbtPlugin._
     Seq(
-      ScoverageKeys.coverageExcludedPackages := "<empty>;testOnlyDoNotUseInAppConf.*;uk.gov.hmrc.lisaapi.views.txt;uk.gov.hmrc;prod.*;definition;uk.gov.hmrc.lisaapi.config.*;uk.gov.hmrc.lisaapi.models.*;",
+      ScoverageKeys.coverageExcludedPackages := "<empty>;testOnlyDoNotUseInAppConf.*;uk.gov.hmrc.lisaapi.views.txt;uk.gov.hmrc;prod.*;definition;uk.gov.hmrc.lisaapi.config.*;uk.gov.hmrc.lisaapi.models.*;dev.*",
       ScoverageKeys.coverageMinimum := 70,
       ScoverageKeys.coverageFailOnMinimum := false,
       ScoverageKeys.coverageHighlighting := true,


### PR DESCRIPTION
(dev package gets built by generators from dev.routes)