### PR TITLE
I think this is why the routes aren't working on QA

### DIFF
--- a/conf/dev.routes
+++ b/conf/dev.routes
@@ -5,5 +5,5 @@
 
 GET         /admin/metrics                                  @com.kenshoo.play.metrics.MetricsController.metrics
 
-POST      /lifetime-isa/manager/:manager/investors        @uk.gov.hmrc.lisaapi.controllers.InvestorController.createLisaInvestor(manager)
-POST      /lifetime-isa/manager/:manager/accounts         @uk.gov.hmrc.lisaapi.controllers.AccountController.createOrTransferLisaAccount(manager)
+POST      /manager/:manager/investors        @uk.gov.hmrc.lisaapi.controllers.InvestorController.createLisaInvestor(manager)
+POST      /manager/:manager/accounts         @uk.gov.hmrc.lisaapi.controllers.AccountController.createOrTransferLisaAccount(manager)

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -4,4 +4,3 @@
 ->          /                                               health.Routes
 
 GET         /admin/metrics                                  @com.kenshoo.play.metrics.MetricsController.metrics
-POST      /lifetime-isa/manager/:manager/investors        @uk.gov.hmrc.lisaapi.controllers.InvestorController.createLisaInvestor(manager)


### PR DESCRIPTION
I believe /lifetime-isa is the base url of the microservice so we shouldn't have it
in the routes.