### PR TITLE
Updated Create Account endpoint

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/services/AccountService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/AccountService.scala
@@ -46,7 +46,6 @@ trait AccountService  {
           case (Some(INVESTOR_NOT_FOUND), _) => CreateLisaAccountInvestorNotFoundResponse
           case (Some(INVESTOR_NOT_ELIGIBLE), _) => CreateLisaAccountInvestorNotEligibleResponse
           case (Some(INVESTOR_COMPLIANCE_FAILED), _) => CreateLisaAccountInvestorComplianceCheckFailedResponse
-          case (Some(INVESTOR_PREVIOUS_ACCOUNT_DOES_NOT_EXIST), _) => CreateLisaAccountInvestorPreviousAccountDoesNotExistResponse
           case (Some(INVESTOR_ACCOUNT_ALREADY_EXISTS), _) => CreateLisaAccountAlreadyExistsResponse
           case (_, _) => CreateLisaAccountErrorResponse
         }

--- a/test/unit/controllers/AccountControllerSpec.scala
+++ b/test/unit/controllers/AccountControllerSpec.scala
@@ -107,17 +107,6 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
       }
     }
 
-    "return with status 403 forbidden and a code of PREVIOUS_INVESTOR_ACCOUNT_DOES_NOT_EXIST" when {
-      "the data service returns a CreateLisaAccountInvestorPreviousAccountDoesNotExistResponse" in {
-        when(mockService.createAccount(any(), any())(any())).thenReturn(Future.successful(CreateLisaAccountInvestorPreviousAccountDoesNotExistResponse))
-
-        doCreateOrTransferRequest(createAccountJson) { res =>
-          status(res) mustBe (FORBIDDEN)
-          (contentAsJson(res) \ "code").as[String] mustBe ("PREVIOUS_INVESTOR_ACCOUNT_DOES_NOT_EXIST")
-        }
-      }
-    }
-
     "return with status 403 forbidden and a code of INVESTOR_ACCOUNT_ALREADY_EXISTS" when {
       "the data service returns a CreateLisaAccountAlreadyExistsResponse" in {
         when(mockService.createAccount(any(), any())(any())).thenReturn(Future.successful(CreateLisaAccountAlreadyExistsResponse))

--- a/test/unit/services/AccountServiceSpec.scala
+++ b/test/unit/services/AccountServiceSpec.scala
@@ -38,7 +38,7 @@ class AccountServiceSpec extends PlaySpec
   val httpStatusCreated = 201
   val unknownRdsCode = 99999
 
-  "Create / Transfer Account" must {
+  "Create Account" must {
 
     "return a Success Response" when {
 
@@ -94,6 +94,20 @@ class AccountServiceSpec extends PlaySpec
             Future.successful((
               httpStatusOk,
               Some(DesAccountResponse(rdsCode = None, accountId = None))
+            ))
+          )
+
+        doCreateRequest { response =>
+          response mustBe CreateLisaAccountErrorResponse
+        }
+      }
+
+      "given the RDS code for a Investor Previous Account Does Not Exist Response" in {
+        when(mockDesConnector.createAccount(any(), any())(any()))
+          .thenReturn(
+            Future.successful((
+              200,
+              Some(DesAccountResponse(rdsCode = Some(SUT.INVESTOR_PREVIOUS_ACCOUNT_DOES_NOT_EXIST)))
             ))
           )
 
@@ -158,20 +172,6 @@ class AccountServiceSpec extends PlaySpec
 
         doCreateRequest { response =>
           response mustBe CreateLisaAccountInvestorComplianceCheckFailedResponse
-        }
-      }
-
-      "given the RDS code for a Investor Previous Account Does Not Exist Response" in {
-        when(mockDesConnector.createAccount(any(), any())(any()))
-          .thenReturn(
-            Future.successful((
-              200,
-              Some(DesAccountResponse(rdsCode = Some(SUT.INVESTOR_PREVIOUS_ACCOUNT_DOES_NOT_EXIST)))
-            ))
-          )
-
-        doCreateRequest { response =>
-          response mustBe CreateLisaAccountInvestorPreviousAccountDoesNotExistResponse
         }
       }
 


### PR DESCRIPTION
As we are not yet dealing with account transfers, we should never get the
PREVIOUS_INVESTOR_ACCOUNT_DOES_NOT_EXIST response. Updated the functionality
to reflect this.