### PR TITLE
Caught some edge cases on TRANSFER_ACCOUNT_DATA_PROVIDED

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.lisaapi.controllers
 
 import play.api.Logger
 import play.api.data.validation.ValidationError
-import play.api.libs.json.{JsPath, JsValue, Json}
+import play.api.libs.json.{JsObject, JsPath, JsValue, Json}
 import play.api.libs.json.Json.toJson
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.lisaapi.models._
@@ -39,7 +39,7 @@ class AccountController extends LisaController {
       (req) => {
         req match {
           case createRequest: CreateLisaAccountCreationRequest => {
-            if (hasAccountTransferData(request.body.asJson.get)) {
+            if (hasAccountTransferData(request.body.asJson.get.as[JsObject])) {
               Future.successful(Forbidden(toJson(ErrorTransferAccountDataProvided)))
             }
             else {
@@ -125,8 +125,8 @@ class AccountController extends LisaController {
     }
   }
 
-  private def hasAccountTransferData(js:JsValue): Boolean = {
-    (js \ "transferAccount").asOpt[AccountTransfer].nonEmpty
+  private def hasAccountTransferData(js:JsObject): Boolean = {
+    js.keys.contains("transferAccount")
   }
 
 }

--- a/test/unit/controllers/AccountControllerSpec.scala
+++ b/test/unit/controllers/AccountControllerSpec.scala
@@ -60,6 +60,15 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
                             |  }
                             |}""".stripMargin
 
+  val createAccountJsonWithInvalidTransfer = """{
+                                        |  "investorID" : "9876543210",
+                                        |  "lisaManagerReferenceNumber" : "Z4321",
+                                        |  "accountID" :"8765432100",
+                                        |  "creationReason" : "New",
+                                        |  "firstSubscriptionDate" : "2011-03-23",
+                                        |  "transferAccount": "X"
+                                        |}""".stripMargin
+
   val transferAccountJson = """{
                             |  "investorID" : "9876543210",
                             |  "lisaManagerReferenceNumber" : "Z4321",
@@ -185,8 +194,20 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
     }
 
     "return with status 403 forbidden and a code of TRANSFER_ACCOUNT_DATA_PROVIDED" when {
-      "sent a create request json with transferAccount data" in {
+      "sent a create request json with full transferAccount data" in {
         doCreateOrTransferRequest(createAccountJsonWithTransfer) { res =>
+          status(res) mustBe (FORBIDDEN)
+          (contentAsJson(res) \ "code").as[String] mustBe ("TRANSFER_ACCOUNT_DATA_PROVIDED")
+        }
+      }
+      "sent a create request json with partial transferAccount data" in {
+        doCreateOrTransferRequest(createAccountJsonWithTransfer.replace("\"transferredFromAccountID\": \"Z543210\",", "")) { res =>
+          status(res) mustBe (FORBIDDEN)
+          (contentAsJson(res) \ "code").as[String] mustBe ("TRANSFER_ACCOUNT_DATA_PROVIDED")
+        }
+      }
+      "sent a create request json with invalid transferAccount data" in {
+        doCreateOrTransferRequest(createAccountJsonWithInvalidTransfer) { res =>
           status(res) mustBe (FORBIDDEN)
           (contentAsJson(res) \ "code").as[String] mustBe ("TRANSFER_ACCOUNT_DATA_PROVIDED")
         }


### PR DESCRIPTION
Previous implementation would successfully validate a Create request provided the transferAccount property (if included) was invalid.