### PR TITLE
LISA-607 Date validation on Create/Transfer endpoint

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/controllers/JsonFormats.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/JsonFormats.scala
@@ -73,7 +73,7 @@ trait JsonFormats {
   implicit val accountTransferReads: Reads[AccountTransfer] = (
     (JsPath \ "transferredFromAccountId").read(Reads.pattern(accountIDRegex, "error.formatting.accountId")) and
     (JsPath \ "transferredFromLMRN").read(Reads.pattern(lmrnRegex, "error.formatting.lmrn")) and
-    (JsPath \ "transferInDate").read(isoDateReads()).map(new DateTime(_))
+    (JsPath \ "transferInDate").read(isoDateReads(allowFutureDates = false)).map(new DateTime(_))
   )(AccountTransfer.apply _)
 
   implicit val accountTransferWrites: Writes[AccountTransfer] = (
@@ -85,7 +85,7 @@ trait JsonFormats {
   implicit val createLisaAccountCreationRequestReads: Reads[CreateLisaAccountCreationRequest] = (
     (JsPath \ "investorId").read(Reads.pattern(investorIDRegex, "error.formatting.investorId")) and
     (JsPath \ "accountId").read(Reads.pattern(accountIDRegex, "error.formatting.accountId")) and
-    (JsPath \ "firstSubscriptionDate").read(isoDateReads()).map(new DateTime(_))
+    (JsPath \ "firstSubscriptionDate").read(isoDateReads(allowFutureDates = false)).map(new DateTime(_))
   )(CreateLisaAccountCreationRequest.apply _)
 
   implicit val createLisaAccountTransferRequestReads: Reads[CreateLisaAccountTransferRequest] = (

--- a/resources/public/api/conf/1.0/examples/BonusPaymentRequest.post.json
+++ b/resources/public/api/conf/1.0/examples/BonusPaymentRequest.post.json
@@ -1,7 +1,7 @@
 {
   "lifeEventId" : "1234567891",
-  "periodStartDate" : "2016-05-22",
-  "periodEndDate" : "2017-05-22",
+  "periodStartDate" : "2017-04-06",
+  "periodEndDate" : "2017-05-05",
   "transactionType" : "Bonus",
 
   "htbTransfer" : {

--- a/resources/public/api/conf/1.0/schemas/BonusPaymentRequest.post.schema.json
+++ b/resources/public/api/conf/1.0/schemas/BonusPaymentRequest.post.schema.json
@@ -89,7 +89,7 @@
         "id": "full-date",
         "type": "string",
         "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-        "example": "2017-05-22"
+        "example": "2017-05-05"
       },
 		"IDType": {
 			"type": "string",

--- a/resources/public/api/conf/1.0/schemas/LISAAccount.close.post.schema.json
+++ b/resources/public/api/conf/1.0/schemas/LISAAccount.close.post.schema.json
@@ -26,7 +26,7 @@
         "id": "full-date",
 		"type": "string",
 		"pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-        "example": "2017-05-22"
+        "example": "2017-05-05"
 	  }
 	}
 

--- a/resources/public/api/conf/1.0/schemas/LISAAccount.post.schema.json
+++ b/resources/public/api/conf/1.0/schemas/LISAAccount.post.schema.json
@@ -21,7 +21,7 @@
       ]
     },
     "firstSubscriptionDate": {
-      "description":"The date of the first deposit into the account - if this is a transfer, use the date of deposit into the account managed by the previous organisation.",
+      "description":"The date of the first deposit into the account - if this is a transfer, use the date of deposit into the account managed by the previous organisation. This can't be in the future.",
       "$ref": "#/definitions/ISO8601-Date"
 
     },
@@ -40,7 +40,7 @@
           "example": "Z4567"
         },
         "transferInDate": {
-          "description": "The date the account transferred from the previous provider to the new one.",
+          "description": "The date the account transferred from the previous provider to the new one. This can't be in the future.",
           "$ref": "#/definitions/ISO8601-Date"
         }
       },

--- a/resources/public/api/conf/1.0/testdata/bonus-payment.md
+++ b/resources/public/api/conf/1.0/testdata/bonus-payment.md
@@ -15,8 +15,8 @@
             <td>
                 <p class ="code--block"> {<br>
                                                "lifeEventId" : "1234567891",<br>
-                                                "periodStartDate" : "2016-05-22",<br>
-                                                "periodEndDate" : "2017-05-22",<br>
+                                                "periodStartDate" : "2017-04-06",<br>
+                                                "periodEndDate" : "2017-05-05",<br>
                                                 "transactionType" : "Penalty",<br>
                                                 "htbTransfer": {<br>
                                                   "htbTransferInForPeriod": 0.00,<br>
@@ -54,8 +54,8 @@
             <td>
                 <p class ="code--block"> {<br>
                                                "lifeEventId" : "1234567891",<br>
-                                                "periodStartDate" : "2016-05-22",<br>
-                                                "periodEndDate" : "2017-05-22",<br>
+                                                "periodStartDate" : "2017-04-06",<br>
+                                                "periodEndDate" : "2017-05-05",<br>
                                                 "transactionType" : "Penalty",<br>
                                                 "htbTransfer": {<br>
                                                   "htbTransferInForPeriod": 0.00,<br>
@@ -89,8 +89,8 @@
             <td>
                 <p class ="code--block"> {<br>
                                                "lifeEventId" : "1234567891",<br>
-                                                "periodStartDate" : "2016-05-22",<br>
-                                                "periodEndDate" : "2017-05-22",<br>
+                                                "periodStartDate" : "2017-04-06",<br>
+                                                "periodEndDate" : "2017-05-05",<br>
                                                 "transactionType" : "Penalty",<br>
                                                 "htbTransfer": {<br>
                                                   "htbTransferInForPeriod": 0.00,<br>
@@ -123,8 +123,8 @@
             <td>
                 <p class ="code--block"> {<br>
                                                "lifeEventId" : "1234567891",<br>
-                                                 "periodStartDate" : "2016-05-22",<br>
-                                                 "periodEndDate" : "2017-05-22",<br>
+                                                 "periodStartDate" : "2017-04-06",<br>
+                                                 "periodEndDate" : "2017-05-05",<br>
                                                  "transactionType" : "Bonus",<br>
                                                  "htbTransfer": {<br>
                                                    "htbTransferInForPeriod": 0.00,<br>
@@ -158,8 +158,8 @@
             <td>
                 <p class ="code--block"> {<br>
                                                "lifeEventId" : "1234567891",<br>
-                                                 "periodStartDate" : "2016-05-22",<br>
-                                                 "periodEndDate" : "2017-05-22",<br>
+                                                 "periodStartDate" : "2017-04-06",<br>
+                                                 "periodEndDate" : "2017-05-05",<br>
                                                  "transactionType" : "Bonus",<br>
                                                  "htbTransfer": {<br>
                                                    "htbTransferInForPeriod": 0.00,<br>
@@ -193,8 +193,8 @@
             <td>
                 <p class ="code--block"> {<br>
                                                "lifeEventId" : "1234567891",<br>
-                                                 "periodStartDate" : "2016-05-22",<br>
-                                                 "periodEndDate" : "2017-05-22",<br>
+                                                 "periodStartDate" : "2017-04-06",<br>
+                                                 "periodEndDate" : "2017-05-05",<br>
                                                  "transactionType" : "Invalid Transaction Type",<br>
                                                  "htbTransfer": {<br>
                                                    "htbTransferInForPeriod": 0.00,<br>
@@ -227,8 +227,8 @@
             <td><p>Request Bonus payment endpoint without lifeEventId and Life Event as claimReason</p><p class ="code--block">lisaManagerReferenceNumber :Z123456<br>accountId: 1110000503</p></td>
             <td>
                 <p class ="code--block"> {<br>
-                                               	"periodStartDate" : "2016-05-22",<br>
-                                               	"periodEndDate" : "2017-05-22",<br>
+                                               	"periodStartDate" : "2017-04-06",<br>
+                                               	"periodEndDate" : "2017-05-05",<br>
                                                	"transactionType" : "Bonus",<br>
                                                	"htbTransfer": {<br>
                                                	"htbTransferInForPeriod": 0.00,<br>
@@ -261,8 +261,8 @@
             <td><p>Request Bonus payment endpoint with Regular Bonus as claim Reason and without lifeEventId (lifeEventId as an optional element)</p><p class ="code--block">lisaManagerReferenceNumber :Z123456<br>accountId: 1110000503</p></td>
             <td>
                 <p class ="code--block"> {<br>
-                                              "periodStartDate" : "2016-05-22",<br>
-                                              "periodEndDate" : "2017-05-22",<br>
+                                              "periodStartDate" : "2017-04-06",<br>
+                                              "periodEndDate" : "2017-05-05",<br>
                                               "transactionType" : "Bonus",<br>
                                               "htbTransfer": {<br>
                                                 "htbTransferInForPeriod": 0.00,<br>
@@ -300,8 +300,8 @@
             <td>
                 <p class ="code--block"> {<br>
                                                "lifeEventId" : "1234567891",<br>
-                                                "periodStartDate" : "2016-05-22",<br>
-                                                "periodEndDate" : "2017-05-22",<br>
+                                                "periodStartDate" : "2017-04-06",<br>
+                                                "periodEndDate" : "2017-05-05",<br>
                                                 "transactionType" : "Penalty",<br>
                                                 "htbTransfer": {<br>
                                                   "htbTransferInForPeriod": 0.00,<br>
@@ -335,8 +335,8 @@
             <td>
                 <p class ="code--block"> {<br>
                                                "lifeEventId" : "1234567891",<br>
-                                                "periodStartDate" : "2016-05-22",<br>
-                                                "periodEndDate" : "2017-05-22",<br>
+                                                "periodStartDate" : "2017-04-06",<br>
+                                                "periodEndDate" : "2017-05-05",<br>
                                                 "transactionType" : "Penalty",<br>
                                                 "htbTransfer": {<br>
                                                   "htbTransferInForPeriod": 0.00,<br>
@@ -370,8 +370,8 @@
             <td>
                 <p class ="code--block"> {<br>
                                                "lifeEventId" : "1234567891",<br>
-                                                "periodStartDate" : "2016-05-22",<br>
-                                                "periodEndDate" : "2017-05-22",<br>
+                                                "periodStartDate" : "2017-04-06",<br>
+                                                "periodEndDate" : "2017-05-05",<br>
                                                 "transactionType" : "Penalty",<br>
                                                 "htbTransfer": {<br>
                                                   "htbTransferInForPeriod": 0.00,<br>

--- a/resources/public/api/conf/1.0/testdata/close-account.md
+++ b/resources/public/api/conf/1.0/testdata/close-account.md
@@ -32,7 +32,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Close Account endpoint without accountClosureReason and (or) closereDate in the payload</p><p class ="code--block">lisaManagerReferenceNumber :Z123456<br>accountId :A1234568</p></td>
+            <td><p>Close Account endpoint without accountClosureReason and (or) closureDate in the payload</p><p class ="code--block">lisaManagerReferenceNumber :Z123456<br>accountId :A1234568</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                      	  "closureDate":"2017-01-03"<br>
@@ -48,7 +48,24 @@
             </td>
         </tr>
         <tr>
-            <td><p>Close Account endpoint with an accountId that doesnot exist</p><p class ="code--block">lisaManagerReferenceNumber :Z123456<br>accountId :A1234562</p></td>
+            <td><p>Close Account endpoint with a closureDate set in the future</p><p class ="code--block">lisaManagerReferenceNumber :Z123456<br>accountId :A1234568</p></td>
+            <td>
+                <p class ="code--block"> {<br>
+                                          "accountClosureReason" : "All funds withdrawn",<br>
+                                     	  "closureDate":"3000-01-01"<br>
+                                        }
+                </p>
+            </td>
+            <td><p>HTTP status: <code class="code--slim">400(Bad RequestOK)</code></p>
+                <p class ="code--block"> {<br>
+                                            "code": "BAD_REQUEST",<br>
+                                            "message": "Bad Request"<br>
+                                       }
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td><p>Close Account endpoint with an accountId that doesn't exist</p><p class ="code--block">lisaManagerReferenceNumber :Z123456<br>accountId :A1234562</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                           "accountClosureReason" : "All funds withdrawn",
@@ -82,7 +99,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Close Account endpoint with a Lisamanager in the URI doesnot exist</p><p class ="code--block">lisaManagerReferenceNumber :Z123456789<br>accountId :A1234561</p></td>
+            <td><p>Close Account endpoint with a Lisa Manager ID in the URI which doesn't exist</p><p class ="code--block">lisaManagerReferenceNumber :Z123456789<br>accountId :A1234561</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                           "accountClosureReason" : "All funds withdrawn",

--- a/resources/public/api/conf/1.0/testdata/lisa-create-investor.md
+++ b/resources/public/api/conf/1.0/testdata/lisa-create-investor.md
@@ -159,6 +159,23 @@
            </td>
         </tr>
         <tr>
+           <td><p>Create Investor endpoint with investor dateOfBirth set in the future</p><p class ="code--block">lisaManagerReferenceNumber :Z123456</p></td>
+           <td><p class ="code--block">{<br>
+                                      "investorNINO":"AA111110A",<br>
+                                       "firstName":"First Name",<br>
+                                       "lastName":"Last Name",<br>
+                                       "dateOfBirth":"3000-01-01"<br>
+                                       }</p>
+           </td>
+           <td><p>HTTP status: <code class="code--slim">400 (Bad Request)</code></p>
+                                 <p class ="code--block">{<br>
+                                                           "code": "BAD_REQUEST",<br>
+                                                           "message": "Bad Request"<br>
+                                                         }
+                                 </p>
+           </td>
+        </tr>
+        <tr>
            <td><p>Create Investor endpoint with investor dateOfBirth in invalid format in the payload</p><p class ="code--block">lisaManagerReferenceNumber :Z123456</p></td>
            <td><p class ="code--block">{<br>
                                       "investorNINO":"AA111110A",<br>

--- a/test/resources/json/request.valid.bonus-payment.json
+++ b/test/resources/json/request.valid.bonus-payment.json
@@ -1,7 +1,7 @@
 {
   "lifeEventId": "1234567891",
-  "periodStartDate": "2016-05-22",
-  "periodEndDate": "2017-05-22",
+  "periodStartDate": "2017-04-06",
+  "periodEndDate": "2017-05-05",
   "transactionType": "Bonus",
 
   "htbTransfer": {

--- a/test/resources/json/request.valid.bonus-payment.min.json
+++ b/test/resources/json/request.valid.bonus-payment.min.json
@@ -1,6 +1,6 @@
 {
-  "periodStartDate": "2016-05-22",
-  "periodEndDate": "2017-05-22",
+  "periodStartDate": "2017-04-06",
+  "periodEndDate": "2017-05-05",
   "transactionType": "Bonus",
 
   "inboundPayments": {

--- a/test/unit/connectors/DesConnectorSpec.scala
+++ b/test/unit/connectors/DesConnectorSpec.scala
@@ -540,8 +540,8 @@ class DesConnectorSpec extends PlaySpec
   private def doRequestBonusPaymentRequest(callback: ((Int, DesResponse)) => Unit) = {
     val request = RequestBonusPaymentRequest(
       lifeEventId = Some("1234567891"),
-      periodStartDate = new DateTime("2016-05-22"),
-      periodEndDate = new DateTime("2017-05-22"),
+      periodStartDate = new DateTime("2017-04-06"),
+      periodEndDate = new DateTime("2017-05-05"),
       transactionType = "Bonus",
       htbTransfer = Some(HelpToBuyTransfer(0f, 0f)),
       inboundPayments = InboundPayments(Some(4000f), 4000f, 4000f, 4000f),

--- a/test/unit/models/RequestBonusPaymentRequestSpec.scala
+++ b/test/unit/models/RequestBonusPaymentRequestSpec.scala
@@ -38,8 +38,8 @@ class RequestBonusPaymentRequestSpec extends PlaySpec with JsonFormats {
         case JsError(errors) => fail(s"Failed to serialize. Errors: ${errors.toString()}")
         case JsSuccess(data, path) => {
           data.lifeEventId mustBe Some("1234567891")
-          data.periodStartDate mustBe new DateTime("2016-05-22")
-          data.periodEndDate mustBe new DateTime("2017-05-22")
+          data.periodStartDate mustBe new DateTime("2017-04-06")
+          data.periodEndDate mustBe new DateTime("2017-05-05")
           data.transactionType mustBe "Bonus"
           data.htbTransfer mustBe Some(HelpToBuyTransfer(0f, 0f))
           data.inboundPayments mustBe InboundPayments(Some(4000f), 4000f, 4000f, 4000f)
@@ -51,8 +51,8 @@ class RequestBonusPaymentRequestSpec extends PlaySpec with JsonFormats {
     "deserialize to json" in {
       val data = RequestBonusPaymentRequest(
         lifeEventId = Some("1234567891"),
-        periodStartDate = new DateTime("2016-05-22"),
-        periodEndDate = new DateTime("2017-05-22"),
+        periodStartDate = new DateTime("2017-04-06"),
+        periodEndDate = new DateTime("2017-05-05"),
         transactionType = "Bonus",
         htbTransfer = Some(HelpToBuyTransfer(0f, 0f)),
         inboundPayments = InboundPayments(Some(4000f), 4000f, 4000f, 4000f),

--- a/test/unit/services/AuditServiceSpec.scala
+++ b/test/unit/services/AuditServiceSpec.scala
@@ -83,8 +83,8 @@ class AuditServiceSpec extends PlaySpec
     "build an audit event with the correct detail when passed a RequestBonusPaymentRequest" in {
       val data = RequestBonusPaymentRequest(
         lifeEventId = Some("1234567891"),
-        periodStartDate = new DateTime("2016-05-22"),
-        periodEndDate = new DateTime("2017-05-22"),
+        periodStartDate = new DateTime("2017-04-06"),
+        periodEndDate = new DateTime("2017-05-05"),
         transactionType = "Bonus",
         htbTransfer = Some(HelpToBuyTransfer(1f, 0f)),
         inboundPayments = InboundPayments(Some(4000f), 4000f, 4000f, 4000f),
@@ -98,8 +98,8 @@ class AuditServiceSpec extends PlaySpec
       val event = captor.getValue
 
       event.detail must contain ("lifeEventId" -> "1234567891")
-      event.detail must contain ("periodStartDate" -> "2016-05-22")
-      event.detail must contain ("periodEndDate" -> "2017-05-22")
+      event.detail must contain ("periodStartDate" -> "2017-04-06")
+      event.detail must contain ("periodEndDate" -> "2017-05-05")
       event.detail must contain ("transactionType" -> "Bonus")
       event.detail must contain ("htbTransferInForPeriod" -> "1.0")
       event.detail must contain ("htbTransferTotalYTD" -> "0.0")

--- a/test/unit/services/BonusPaymentServiceSpec.scala
+++ b/test/unit/services/BonusPaymentServiceSpec.scala
@@ -60,8 +60,8 @@ class BonusPaymentServiceSpec extends PlaySpec with MockitoSugar with OneAppPerS
   private def doRequest(callback: (RequestBonusPaymentResponse) => Unit) = {
     val request = RequestBonusPaymentRequest(
       lifeEventId = Some("1234567891"),
-      periodStartDate = new DateTime("2016-05-22"),
-      periodEndDate = new DateTime("2017-05-22"),
+      periodStartDate = new DateTime("2017-04-06"),
+      periodEndDate = new DateTime("2017-05-05"),
       transactionType = "Bonus",
       htbTransfer = Some(HelpToBuyTransfer(0f, 0f)),
       inboundPayments = InboundPayments(Some(4000f), 4000f, 4000f, 4000f),


### PR DESCRIPTION
Added validation checks to the dates on the Create/Transfer endpoint to ensure they are not in the future.

Updated API spec to ensure no future dates were being used in the test data examples unless it was a specific example of failing date validation.

Fixed a couple of typos.