### PR TITLE
LISA-903: Bug fix for 'creationReason' field

### DIFF
--- a/test/unit/models/CreateLisaAccountRequestSpec.scala
+++ b/test/unit/models/CreateLisaAccountRequestSpec.scala
@@ -149,11 +149,7 @@ class CreateLisaAccountRequestSpec extends PlaySpec {
 
       res match {
         case JsError(errors) => {
-          errors.count {
-            case (path: JsPath, errors: Seq[ValidationError]) => {
-              path.toString() == "/creationReason" && errors.contains(ValidationError("error.formatting.creationReason"))
-            }
-          } mustBe 1
+          errors mustBe Seq((JsPath \ "creationReason", Seq(ValidationError("error.formatting.creationReason"))))
         }
         case _ => fail()
       }
@@ -165,11 +161,7 @@ class CreateLisaAccountRequestSpec extends PlaySpec {
 
       res match {
         case JsError(errors) => {
-          errors.count {
-            case (path: JsPath, errors: Seq[ValidationError]) => {
-              path.toString() == "/creationReason" && errors.contains(ValidationError("error.expected.jsstring"))
-            }
-          } mustBe 1
+          errors mustBe Seq((JsPath \ "creationReason", Seq(ValidationError("error.expected.jsstring"))))
         }
         case _ => fail()
       }
@@ -181,11 +173,7 @@ class CreateLisaAccountRequestSpec extends PlaySpec {
 
       res match {
         case JsError(errors) => {
-          errors.count {
-            case (path: JsPath, errors: Seq[ValidationError]) => {
-              path.toString() == "/creationReason" && errors.contains(ValidationError("error.path.missing"))
-            }
-          } mustBe 1
+          errors mustBe Seq((JsPath \ "creationReason", Seq(ValidationError("error.path.missing"))))
         }
         case _ => fail()
       }
@@ -197,11 +185,7 @@ class CreateLisaAccountRequestSpec extends PlaySpec {
 
       res match {
         case JsError(errors) => {
-          errors.count {
-            case (path: JsPath, errors: Seq[ValidationError]) => {
-              path.toString() == "/transferAccount" && errors.contains(ValidationError("error.path.missing"))
-            }
-          } mustBe 1
+          errors mustBe Seq((JsPath \ "creationReason", Seq(ValidationError("error.path.missing"))))
         }
         case _ => fail()
       }

--- a/test/unit/models/CreateLisaAccountRequestSpec.scala
+++ b/test/unit/models/CreateLisaAccountRequestSpec.scala
@@ -167,8 +167,8 @@ class CreateLisaAccountRequestSpec extends PlaySpec {
       }
     }
 
-    "catch an missing creationReason value" in {
-      val req = validAccountTransferRequest.replace("\"creationReason\": \"Transferred\",", "")
+    "catch a missing creationReason value" in {
+      val req = validAccountCreationRequest.replace("\"creationReason\": \"New\",", "")
       val res = Json.parse(req).validate[CreateLisaAccountRequest]
 
       res match {
@@ -185,7 +185,7 @@ class CreateLisaAccountRequestSpec extends PlaySpec {
 
       res match {
         case JsError(errors) => {
-          errors mustBe Seq((JsPath \ "creationReason", Seq(ValidationError("error.path.missing"))))
+          errors mustBe Seq((JsPath \ "transferAccount", Seq(ValidationError("error.path.missing"))))
         }
         case _ => fail()
       }

--- a/test/unit/models/CreateLisaAccountRequestSpec.scala
+++ b/test/unit/models/CreateLisaAccountRequestSpec.scala
@@ -151,7 +151,7 @@ class CreateLisaAccountRequestSpec extends PlaySpec {
         case JsError(errors) => {
           errors.count {
             case (path: JsPath, errors: Seq[ValidationError]) => {
-              errors.contains(ValidationError("error.formatting.creationReason"))
+              path.toString() == "/creationReason" && errors.contains(ValidationError("error.formatting.creationReason"))
             }
           } mustBe 1
         }
@@ -167,7 +167,23 @@ class CreateLisaAccountRequestSpec extends PlaySpec {
         case JsError(errors) => {
           errors.count {
             case (path: JsPath, errors: Seq[ValidationError]) => {
-              errors.contains(ValidationError("error.expected.jsstring"))
+              path.toString() == "/creationReason" && errors.contains(ValidationError("error.expected.jsstring"))
+            }
+          } mustBe 1
+        }
+        case _ => fail()
+      }
+    }
+
+    "catch an missing creationReason value" in {
+      val req = validAccountTransferRequest.replace("\"creationReason\": \"Transferred\",", "")
+      val res = Json.parse(req).validate[CreateLisaAccountRequest]
+
+      res match {
+        case JsError(errors) => {
+          errors.count {
+            case (path: JsPath, errors: Seq[ValidationError]) => {
+              path.toString() == "/creationReason" && errors.contains(ValidationError("error.path.missing"))
             }
           } mustBe 1
         }


### PR DESCRIPTION
Fixes LISA-903 and LISA-901:

A missing or invalid 'creationReason' on a account creation/transfer request will now return the correct error message.

Had to make the response slightly opinionated as if they were intending a creation request but this seemed the simplest approach as it shares all the same fields as a transfer request, only missing out the transfer object.