### PR TITLE
LISA-690: Consolidated periodEndDate rules to avoid duplicate errors

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
+++ b/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
@@ -115,7 +115,7 @@ trait BonusPaymentValidator {
   }
 
   private val periodStartDateIsSixth: PartialFunction[BonusPaymentValidationRequest, BonusPaymentValidationRequest] = {
-    case req: BonusPaymentValidationRequest if req.data.periodStartDate.dayOfMonth().get() != 6 => {
+    case req: BonusPaymentValidationRequest if req.data.periodStartDate.getDayOfMonth() != 6 => {
       req.copy(errors = req.errors :+ ErrorValidation(dateErrorCode, "The periodStartDate must equal the 6th day of the month", Some(s"/periodStartDate")))
     }
     case req: BonusPaymentValidationRequest => req


### PR DESCRIPTION
Having them as two separate rules could cause both rules to fail and the same validation error to display twice.