### PR TITLE
LISA-1387: Spec update for report a life event

### DIFF
--- a/resources/public/api/conf/1.0/testdata/life-event.md
+++ b/resources/public/api/conf/1.0/testdata/life-event.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager Reference Number and Account ID</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile<a><br>accountId: 1234567890</p></td>
+            <td><p>Request with a valid payload, LISA Manager Reference Number and Account ID</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                             "eventType" : "LISA Investor Terminal Ill Health",<br>
@@ -49,7 +49,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile<a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                             "eventType" : "Invalid Event Type"<br>
@@ -77,7 +77,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a life event that conflicts with a previously reported event</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile<a><br>accountId: 0000000403</p></td>
+            <td><p>Request containing a life event that conflicts with a previously reported event</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 0000000403</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                             "eventType" : "LISA Investor Terminal Ill Health",<br>
@@ -94,7 +94,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been closed or voided</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile<a><br>accountId: 0000000903</p></td>
+            <td><p>Request for an account that has already been closed or voided</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 0000000903</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                             "eventType" : "LISA Investor Terminal Ill Health",<br>
@@ -110,7 +110,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an Account ID that does not exist</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile<a><br>accountId: 0000000404</p></td>
+            <td><p>Request containing an Account ID that does not exist</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 0000000404</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                             "eventType" : "LISA Investor Terminal Ill Health",<br>
@@ -127,7 +127,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile<a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                             "eventType" : "LISA Investor Terminal Ill Health",<br>
@@ -144,7 +144,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an already reported event</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile<a><br>accountId: 0000000409</p></td>
+            <td><p>Request containing an already reported event</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 0000000409</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                             "eventType" : "LISA Investor Terminal Ill Health",<br>
@@ -155,7 +155,8 @@
             <td><p>HTTP status: <code class="code--slim">409 (Conflict)</code></p>
                 <p class ="code--block"> {<br>
                                             "code": "LIFE_EVENT_ALREADY_EXISTS",<br>
-                                            "message": "The investor’s life event has already been reported"<br>
+                                            "message": "The investor’s life event has already been reported",<br>
+                                            "lifeEventId": "1234567890"<br>
                                           }
                 </p>
             </td>


### PR DESCRIPTION
409 Conflict response now contains the lifeEventId of the duplicate event, allowing the user to update their records.