### PR TITLE
Update copyright dates to 2018

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/config/APIAccessConfig.scala
+++ b/app/uk/gov/hmrc/lisaapi/config/APIAccessConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/config/AppContext.scala
+++ b/app/uk/gov/hmrc/lisaapi/config/AppContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/config/microserviceGlobal.scala
+++ b/app/uk/gov/hmrc/lisaapi/config/microserviceGlobal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/config/microserviceWiring.scala
+++ b/app/uk/gov/hmrc/lisaapi/config/microserviceWiring.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/connectors/ServiceLocatorConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/ServiceLocatorConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/BonusPaymentController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/BonusPaymentController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/DiscoverController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/DiscoverController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/DocumentationController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/DocumentationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/InvestorController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/InvestorController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/LifeEventController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/LifeEventController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/LisaController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/LisaController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/ReinstateAccountController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/ReinstateAccountController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/Responses.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/Responses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/TransactionController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/TransactionController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/controllers/package.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/domain/APIAccess.scala
+++ b/app/uk/gov/hmrc/lisaapi/domain/APIAccess.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/domain/Registration.scala
+++ b/app/uk/gov/hmrc/lisaapi/domain/Registration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/metrics/LisaMetrics.scala
+++ b/app/uk/gov/hmrc/lisaapi/metrics/LisaMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/AccountTransfer.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/AccountTransfer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/ApiResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/ApiResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/ApiResponseData.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/ApiResponseData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/CloseLisaAccountRequest.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/CloseLisaAccountRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/CloseLisaAccountResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/CloseLisaAccountResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/CreateLisaAccountRequest.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/CreateLisaAccountRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/CreateLisaAccountResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/CreateLisaAccountResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/CreateLisaInvestorRequest.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/CreateLisaInvestorRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/CreateLisaInvestorResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/CreateLisaInvestorResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/GetBonusPaymentResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/GetBonusPaymentResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/GetLisaAccountResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/GetLisaAccountResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/GetTransactionResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/GetTransactionResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/ReinstateLisaAccountResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/ReinstateLisaAccountResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/ReportLifeEventRequest.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/ReportLifeEventRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/ReportLifeEventResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/ReportLifeEventResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/RequestBonusPaymentRequest.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/RequestBonusPaymentRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/RequestBonusPaymentResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/RequestBonusPaymentResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/ResorceModel.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/ResorceModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/UpdateSubscriptionRequest.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/UpdateSubscriptionRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/UpdateSubscriptionResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/UpdateSubscriptionResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/des/DesGetTransactionResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/des/DesGetTransactionResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/des/DesResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/des/DesResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/models/package.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/services/AccountService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/AccountService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/services/AuditService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/AuditService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/services/BonusPaymentService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/BonusPaymentService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/services/CurrentDateService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/CurrentDateService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/services/InvestorService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/InvestorService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/services/LifeEventService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/LifeEventService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/services/ReinstateAccountService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/ReinstateAccountService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/services/TransactionService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/TransactionService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/services/UpdateSubscriptionService.scala
+++ b/app/uk/gov/hmrc/lisaapi/services/UpdateSubscriptionService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
+++ b/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/utils/ErrorConverter.scala
+++ b/app/uk/gov/hmrc/lisaapi/utils/ErrorConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/lisaapi/utils/LisaExtensions.scala
+++ b/app/uk/gov/hmrc/lisaapi/utils/LisaExtensions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2017 HM Revenue & Customs
+# Copyright 2018 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
SBT will automatically update all the copyright dates to 2018. Best to just add this as an individual PR rather than have it pollute other feature branches.