### PR TITLE
LISA-1529: Updated accountId regex

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/controllers/LisaController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/LisaController.scala
@@ -52,7 +52,7 @@ trait LisaController extends BaseController with HeaderValidator with RunMode wi
   }
 
   protected def withValidAccountId(accountId: String)(success: Future[Result])(implicit request: Request[AnyContent]): Future[Result] = {
-    if (accountId.matches("^[a-zA-Z0-9 :\\-]{1,20}$")) {
+    if (accountId.matches("^[a-zA-Z0-9 :/-]{1,20}$")) {
       success
     }
     else {

--- a/app/uk/gov/hmrc/lisaapi/models/package.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/package.scala
@@ -55,7 +55,7 @@ package object models {
       "^[a-zA-Z &`\\-\\'^]{1,35}$".r,
       "error.formatting.name")
     val investorId: Reads[InvestorId] = Reads.pattern("^\\d{10}$".r, "error.formatting.investorId")
-    val accountId: Reads[AccountId] = Reads.pattern("^[a-zA-Z0-9 :\\-]{1,20}$".r, "error.formatting.accountId")
+    val accountId: Reads[AccountId] = Reads.pattern("^[a-zA-Z0-9 :/-]{1,20}$".r, "error.formatting.accountId")
     val lifeEventId: Reads[LifeEventId] = Reads.pattern("^\\d{10}$".r, "error.formatting.lifeEventId")
     val lifeEventType: Reads[LifeEventType] = Reads.pattern("^(LISA Investor Terminal Ill Health|LISA Investor Death)$".r, "error.formatting.lifeEventType")
     val accountClosureReason: Reads[AccountClosureReason] = Reads.pattern(

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -31,7 +31,7 @@ types:
   LISAManagerReferenceNumberType:
     pattern: "^Z([0-9]{4}|[0-9]{6})$"
   accountIdType:
-    "pattern": "^[a-zA-Z0-9 :\\-]{1,20}$"
+    "pattern": "^[a-zA-Z0-9 :/-]{1,20}$"
   ISO8601Date:
     "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
 

--- a/resources/public/api/conf/1.0/schemas/LISAAccount.get.schema.json
+++ b/resources/public/api/conf/1.0/schemas/LISAAccount.get.schema.json
@@ -99,7 +99,7 @@
       "accountIdType": {
         "type": "string",
         "example": "AB9876543210",
-        "pattern": "^[a-zA-Z0-9 :\\-]{1,20}$"
+        "pattern": "^[a-zA-Z0-9 :/-]{1,20}$"
       }
     }
 

--- a/resources/public/api/conf/1.0/schemas/LISAAccount.post.schema.json
+++ b/resources/public/api/conf/1.0/schemas/LISAAccount.post.schema.json
@@ -81,7 +81,7 @@
       "accountIdType": {
         "type": "string",
         "example": "AB9876543210",
-        "pattern": "^[a-zA-Z0-9 :\\-]{1,20}$"
+        "pattern": "^[a-zA-Z0-9 :/-]{1,20}$"
       }
     }
 

--- a/resources/public/api/conf/1.0/schemas/LISAAccount.reinstate.post.schema.json
+++ b/resources/public/api/conf/1.0/schemas/LISAAccount.reinstate.post.schema.json
@@ -16,7 +16,7 @@
     "accountIdType": {
       "type": "string",
       "example": "AB9876543210",
-      "pattern": "^[a-zA-Z0-9 :\\-]{1,20}$"
+      "pattern": "^[a-zA-Z0-9 :/-]{1,20}$"
     }
   }
 }

--- a/test/unit/controllers/AccountControllerSpec.scala
+++ b/test/unit/controllers/AccountControllerSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{AnyContentAsJson, Result}
 import play.api.test.Helpers._
 import play.api.test._
@@ -49,18 +49,18 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
 
   val createAccountJson = """{
                             |  "investorId" : "9876543210",
-                            |  "accountId" :"8765432100",
+                            |  "accountId" :"8765/432100",
                             |  "creationReason" : "New",
                             |  "firstSubscriptionDate" : "2011-03-23"
                             |}""".stripMargin
 
   val createAccountJsonWithTransfer = """{
                                         |  "investorId" : "9876543210",
-                                        |  "accountId" :"8765432100",
+                                        |  "accountId" :"8765/432100",
                                         |  "creationReason" : "New",
                                         |  "firstSubscriptionDate" : "2011-03-23",
                                         |  "transferAccount": {
-                                        |    "transferredFromAccountId": "Z543210",
+                                        |    "transferredFromAccountId": "Z54/3210",
                                         |    "transferredFromLMRN": "Z543333",
                                         |    "transferInDate": "2015-12-13"
                                         |  }
@@ -68,7 +68,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
 
   val createAccountJsonWithInvalidTransfer = """{
                                                |  "investorId" : "9876543210",
-                                               |  "accountId" :"8765432100",
+                                               |  "accountId" :"8765/432100",
                                                |  "creationReason" : "New",
                                                |  "firstSubscriptionDate" : "2011-03-23",
                                                |  "transferAccount": "X"
@@ -76,11 +76,11 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
 
   val transferAccountJson = """{
                               |  "investorId" : "9876543210",
-                              |  "accountId" :"8765432100",
+                              |  "accountId" :"8765/432100",
                               |  "creationReason" : "Transferred",
                               |  "firstSubscriptionDate" : "2011-03-23",
                               |  "transferAccount": {
-                              |    "transferredFromAccountId": "Z543210",
+                              |    "transferredFromAccountId": "Z54/3210",
                               |    "transferredFromLMRN": "Z543333",
                               |    "transferInDate": "2015-12-13"
                               |  }
@@ -88,13 +88,12 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
 
   val transferAccountJsonIncomplete = """{
                                         |  "investorId" : "9876543210",
-                                        |  "accountId" :"8765432100",
+                                        |  "accountId" :"8765/432100",
                                         |  "creationReason" : "Transferred",
                                         |  "firstSubscriptionDate" : "2011-03-23"
                                         |}""".stripMargin
 
   val closeAccountJson = """{"accountClosureReason" : "All funds withdrawn", "closureDate" : "2000-06-23"}"""
-
 
   "The Create / Transfer Account endpoint" must {
 
@@ -110,7 +109,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23"
             )))(any())
         }
@@ -128,7 +127,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
               "reasonNotCreated" -> "INVESTOR_NOT_FOUND"
             )))(any())
@@ -144,7 +143,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
               "reasonNotCreated" -> "INVESTOR_ELIGIBILITY_CHECK_FAILED"
             ))
@@ -161,7 +160,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
               "reasonNotCreated" -> "INVESTOR_COMPLIANCE_CHECK_FAILED"
             ))
@@ -178,9 +177,9 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
-              "transferredFromAccountId" -> "Z543210",
+              "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
               "transferInDate" -> "2015-12-13",
               "reasonNotCreated" -> "PREVIOUS_INVESTOR_ACCOUNT_DOES_NOT_EXIST"
@@ -198,7 +197,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_EXISTS"
             ))
@@ -215,7 +214,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
               "reasonNotCreated" -> "INTERNAL_SERVER_ERROR"
             ))
@@ -234,9 +233,9 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
-              "transferredFromAccountId" -> "Z543210",
+              "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
               "transferInDate" -> "2015-12-13"
             )))(any())
@@ -255,9 +254,9 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
-              "transferredFromAccountId" -> "Z543210",
+              "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
               "transferInDate" -> "2015-12-13",
               "reasonNotCreated" -> "INVESTOR_NOT_FOUND"
@@ -274,9 +273,9 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
-              "transferredFromAccountId" -> "Z543210",
+              "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
               "transferInDate" -> "2015-12-13",
               "reasonNotCreated" -> "INVESTOR_COMPLIANCE_CHECK_FAILED"
@@ -293,9 +292,9 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
-              "transferredFromAccountId" -> "Z543210",
+              "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
               "transferInDate" -> "2015-12-13",
               "reasonNotCreated" -> "PREVIOUS_INVESTOR_ACCOUNT_DOES_NOT_EXIST"
@@ -312,9 +311,9 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
-              "transferredFromAccountId" -> "Z543210",
+              "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
               "transferInDate" -> "2015-12-13",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
@@ -331,9 +330,9 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
-              "transferredFromAccountId" -> "Z543210",
+              "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
               "transferInDate" -> "2015-12-13",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_VOID"
@@ -350,9 +349,9 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
-              "transferredFromAccountId" -> "Z543210",
+              "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
               "transferInDate" -> "2015-12-13",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_EXISTS"
@@ -369,9 +368,9 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
-              "accountId" -> "8765432100",
+              "accountId" -> "8765/432100",
               "firstSubscriptionDate" -> "2011-03-23",
-              "transferredFromAccountId" -> "Z543210",
+              "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
               "transferInDate" -> "2015-12-13",
               "reasonNotCreated" -> "INTERNAL_SERVER_ERROR"
@@ -415,6 +414,22 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
           val json = contentAsJson(res)
           (json \ "code").as[String] mustBe ErrorBadRequestLmrn.errorCode
           (json \ "message").as[String] mustBe ErrorBadRequestLmrn.message
+        }
+      }
+      "invalid accountId is sent" in {
+        when(mockService.createAccount(any(), any())(any())).thenReturn(Future.successful(CreateLisaAccountSuccessResponse("AB123456")))
+
+        doCreateOrTransferRequest(transferAccountJson.replace("/", "\\\\")) { res =>
+          status(res) mustBe (BAD_REQUEST)
+
+          val json = contentAsJson(res)
+          (json \ "code").as[String] mustBe "BAD_REQUEST"
+          (json \ "message").as[String] mustBe "Bad Request"
+
+          val errors = (json \ "errors").as[List[JsObject]]
+
+          errors must contain(Json.obj("code" -> "INVALID_FORMAT", "message" -> "Invalid format has been used", "path" -> "/accountId"))
+          errors must contain(Json.obj("code" -> "INVALID_FORMAT", "message" -> "Invalid format has been used", "path" -> "/transferAccount/transferredFromAccountId"))
         }
       }
     }

--- a/test/unit/controllers/BonusPaymentControllerSpec.scala
+++ b/test/unit/controllers/BonusPaymentControllerSpec.scala
@@ -47,7 +47,7 @@ class BonusPaymentControllerSpec extends PlaySpec
 
   val acceptHeader: (String, String) = (HeaderNames.ACCEPT, "application/vnd.hmrc.1.0+json")
   val lisaManager = "Z019283"
-  val accountId = "ABC12345"
+  val accountId = "ABC/12345"
   val transactionId = "1234567890"
   val validBonusPaymentJson = Source.fromInputStream(getClass().getResourceAsStream("/json/request.valid.bonus-payment.json")).mkString
   val validBonusPaymentMinimumFieldsJson = Source.fromInputStream(getClass().getResourceAsStream("/json/request.valid.bonus-payment.min.json")).mkString

--- a/test/unit/controllers/LifeEventControllerSpec.scala
+++ b/test/unit/controllers/LifeEventControllerSpec.scala
@@ -45,7 +45,7 @@ class LifeEventControllerSpec extends PlaySpec
 
   val acceptHeader: (String, String) = (HeaderNames.ACCEPT, "application/vnd.hmrc.1.0+json")
   val lisaManager = "Z019283"
-  val accountId = "ABC12345"
+  val accountId = "ABC/12345"
   val eventId = "1234567890"
 
   implicit val hc:HeaderCarrier = HeaderCarrier()

--- a/test/unit/controllers/ReinstateAccountControllerSpec.scala
+++ b/test/unit/controllers/ReinstateAccountControllerSpec.scala
@@ -39,24 +39,20 @@ class ReinstateAccountControllerSpec extends PlaySpec with MockitoSugar with One
 
   val acceptHeader: (String, String) = (HeaderNames.ACCEPT, "application/vnd.hmrc.1.0+json")
   val lisaManager = "Z019283"
-  val accountId = "ABC12345"
+  val accountId = "ABC/12345"
   val mockAuthCon = mock[LisaAuthConnector]
 
   override def beforeEach() {
     reset(mockAuditService)
   }
 
-
-  val reinstateAccountValidJson = """{"accountId" :"ABC12345"}"""
-
-
+  val reinstateAccountValidJson = s"""{"accountId" :"$accountId"}"""
 
   "The Reinstate Account endpoint" must {
 
     when(mockAuthCon.authorise[Option[String]](any(),any())(any(), any())).thenReturn(Future(Some("1234")))
 
     "audit an account reinstated event" when {
-
       "return with status 200 ok" when {
         "submitted a valid reinstate account request" in {
           when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountSuccessResponse("code", "reason")))
@@ -64,10 +60,10 @@ class ReinstateAccountControllerSpec extends PlaySpec with MockitoSugar with One
           doSyncReinstateAccount (reinstateAccountValidJson){ res =>
             verify(mockAuditService).audit(
               auditType = matchersEquals("accountReinstated"),
-              path=matchersEquals(s"/manager/$lisaManager/accounts/ABC12345/reinstate"),
+              path=matchersEquals(s"/manager/$lisaManager/accounts/$accountId/reinstate"),
               auditData = matchersEquals(Map(
                 "lisaManagerReferenceNumber" -> lisaManager,
-                "accountId" -> "ABC12345"
+                "accountId" -> accountId
                )))(any())
           }
         }
@@ -78,95 +74,86 @@ class ReinstateAccountControllerSpec extends PlaySpec with MockitoSugar with One
       "the data service returns a ReinstateLisaAccountAlreadyClosedResponse" in {
         when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountAlreadyClosedResponse))
 
-        doSyncReinstateAccount (reinstateAccountValidJson) { res =>
+        doSyncReinstateAccount(reinstateAccountValidJson) { res =>
           verify(mockAuditService).audit(
             auditType = matchersEquals("accountNotReinstated"),
-            path = matchersEquals(s"/manager/$lisaManager/accounts/ABC12345/reinstate"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/reinstate"),
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
-              "accountId" -> "ABC12345",
+              "accountId" -> accountId,
               "reasonNotReinstated" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
             )))(any())
         }
       }
+      "the data service returns a ReinstateLisaAccountAlreadyCancelledResponse" in {
+        when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountAlreadyCancelledResponse))
 
-       "the data service returns a ReinstateLisaAccountAlreadyCancelledResponse" in {
-          when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountAlreadyCancelledResponse))
-
-         doSyncReinstateAccount (reinstateAccountValidJson){ res =>
-           verify(mockAuditService).audit(
-             auditType = matchersEquals("accountNotReinstated"),
-             path = matchersEquals(s"/manager/$lisaManager/accounts/ABC12345/reinstate"),
-             auditData = matchersEquals(Map(
-               "lisaManagerReferenceNumber" -> lisaManager,
-               "accountId" -> "ABC12345",
-               "reasonNotReinstated" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
-             )))(any())
-          }
+        doSyncReinstateAccount(reinstateAccountValidJson) { res =>
+          verify(mockAuditService).audit(
+            auditType = matchersEquals("accountNotReinstated"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/reinstate"),
+            auditData = matchersEquals(Map(
+              "lisaManagerReferenceNumber" -> lisaManager,
+              "accountId" -> accountId,
+              "reasonNotReinstated" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
+            )))(any())
         }
-
+      }
       "the data service returns a ReinstateLisaAccountAlreadyOpenResponse" in {
         when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountAlreadyOpenResponse))
 
-        doSyncReinstateAccount (reinstateAccountValidJson){ res =>
+        doSyncReinstateAccount(reinstateAccountValidJson) { res =>
           verify(mockAuditService).audit(
             auditType = matchersEquals("accountNotReinstated"),
-            path = matchersEquals(s"/manager/$lisaManager/accounts/ABC12345/reinstate"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/reinstate"),
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
-              "accountId" -> "ABC12345",
+              "accountId" -> accountId,
               "reasonNotReinstated" -> "INVESTOR_ACCOUNT_ALREADY_OPEN"
             )))(any())
         }
       }
-
       "the data service returns a ReinstateLisaAccountInvestorComplianceCheckFailedResponse" in {
         when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountInvestorComplianceCheckFailedResponse))
 
-        doSyncReinstateAccount (reinstateAccountValidJson){ res =>
+        doSyncReinstateAccount(reinstateAccountValidJson) { res =>
           verify(mockAuditService).audit(
             auditType = matchersEquals("accountNotReinstated"),
-            path = matchersEquals(s"/manager/$lisaManager/accounts/ABC12345/reinstate"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/reinstate"),
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
-              "accountId" -> "ABC12345",
+              "accountId" -> accountId,
               "reasonNotReinstated" -> "INVESTOR_COMPLIANCE_CHECK_FAILED"
             )))(any())
         }
       }
-
-
       "the data service returns a ReinstateLisaAccountNotFoundResponse" in {
         when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountNotFoundResponse))
 
-        doSyncReinstateAccount (reinstateAccountValidJson){ res =>
+        doSyncReinstateAccount(reinstateAccountValidJson) { res =>
           verify(mockAuditService).audit(
             auditType = matchersEquals("accountNotReinstated"),
-            path = matchersEquals(s"/manager/$lisaManager/accounts/ABC12345/reinstate"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/reinstate"),
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
-              "accountId" -> "ABC12345",
+              "accountId" -> accountId,
               "reasonNotReinstated" -> "INVESTOR_ACCOUNTID_NOT_FOUND"
             )))(any())
 
         }
       }
+      "the data service returns an error" in {
+        when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountErrorResponse))
 
-      "return with status 500 internal server error" when {
-        "the data service returns an error" in {
-          when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountErrorResponse))
-
-          doSyncReinstateAccount (reinstateAccountValidJson){ res =>
-            verify(mockAuditService).audit(
-              auditType = matchersEquals("accountNotReinstated"),
-              path=matchersEquals(s"/manager/$lisaManager/accounts/ABC12345/reinstate"),
-              auditData = matchersEquals(Map(
-                "lisaManagerReferenceNumber" -> lisaManager,
-                "accountId" -> "ABC12345",
-                "reasonNotReinstated" -> "INTERNAL_SERVER_ERROR"
-              )))(any())
-
-          }
+        doSyncReinstateAccount (reinstateAccountValidJson){ res =>
+          verify(mockAuditService).audit(
+            auditType = matchersEquals("accountNotReinstated"),
+            path=matchersEquals(s"/manager/$lisaManager/accounts/$accountId/reinstate"),
+            auditData = matchersEquals(Map(
+              "lisaManagerReferenceNumber" -> lisaManager,
+              "accountId" -> accountId,
+              "reasonNotReinstated" -> "INTERNAL_SERVER_ERROR"
+            )))(any())
         }
       }
     }
@@ -225,7 +212,6 @@ class ReinstateAccountControllerSpec extends PlaySpec with MockitoSugar with One
       }
     }
 
-
     "return with status 404 forbidden and a code of INVESTOR_ACCOUNTID_NOT_FOUND" when {
       "the data service returns a ReinstateLisaAccountNotFoundResponse" in {
         when(mockService.reinstateAccountService(any(), any())(any())).thenReturn(Future.successful(ReinstateLisaAccountNotFoundResponse))
@@ -260,9 +246,6 @@ class ReinstateAccountControllerSpec extends PlaySpec with MockitoSugar with One
 
   }
 
-
-
-
   def doReinstateRequest(jsonString: String, lmrn: String = lisaManager)(callback: (Future[Result]) => Unit) {
     val res = SUT.reinstateAccount(lmrn).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
       withBody(AnyContentAsJson(Json.parse(jsonString))))
@@ -270,16 +253,12 @@ class ReinstateAccountControllerSpec extends PlaySpec with MockitoSugar with One
     callback(res)
   }
 
-
   def doSyncReinstateAccount(jsonString: String)(callback: (Result) => Unit) {
     val res = await(SUT.reinstateAccount(lisaManager).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
       withBody(AnyContentAsJson(Json.parse(jsonString)))))
 
     callback(res)
   }
-
-
-
 
   val mockService: ReinstateAccountService = mock[ReinstateAccountService]
   val mockAuditService: AuditService = mock[AuditService]

--- a/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
+++ b/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
@@ -41,7 +41,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
 
   val acceptHeader: (String, String) = (HeaderNames.ACCEPT, "application/vnd.hmrc.1.0+json")
   val lisaManager = "Z019283"
-  val accountId = "1234567890"
+  val accountId = "1234/567890"
   val mockAuthCon = mock[LisaAuthConnector]
 
   implicit val hc:HeaderCarrier = HeaderCarrier()
@@ -229,7 +229,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
 
 
   def doUpdateSubsDate(jsonString: String)(callback: (Future[Result]) => Unit) {
-    val res = SUT.updateSubscription(lisaManager, "1234567890").apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
+    val res = SUT.updateSubscription(lisaManager, accountId).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
       withBody(AnyContentAsJson(Json.parse(jsonString))))
 
     callback(res)
@@ -237,7 +237,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
 
 
   def doUpdateSubsDateInvalidLMRN(jsonString: String)(callback: (Future[Result]) => Unit) {
-    val res = SUT.updateSubscription("12345678", "1234567890").apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
+    val res = SUT.updateSubscription("12345678", accountId).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
       withBody(AnyContentAsJson(Json.parse(jsonString))))
 
     callback(res)


### PR DESCRIPTION
Back slashes are now disallowed from accountId and forward slashes are allowed.