### PR TITLE
LISA-1663: Added date validation

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
@@ -319,10 +319,6 @@ class AccountController extends LisaController with LisaConstants {
       }
     }
 
-    private def getAccountDetailsEndpointUrl(lisaManagerReferenceNumber: String, accountId: String): String = {
-      s"/manager/$lisaManagerReferenceNumber/accounts/$accountId"
-    }
-
   //endregion
 
   //region Close Account
@@ -339,7 +335,8 @@ class AccountController extends LisaController with LisaConstants {
       }
     }
 
-    private def processAccountClosure(lisaManager: String, accountId: String, closeLisaAccountRequest: CloseLisaAccountRequest)(implicit hc: HeaderCarrier, startTime:Long) = {
+    private def processAccountClosure(lisaManager: String, accountId: String, closeLisaAccountRequest: CloseLisaAccountRequest)
+                                     (implicit hc: HeaderCarrier, startTime:Long) = {
       if (closeLisaAccountRequest.closureDate.isBefore(LISA_START_DATE)) {
         auditService.audit(
           auditType = "accountNotClosed",
@@ -453,10 +450,12 @@ class AccountController extends LisaController with LisaConstants {
             }
           }
         } recover {
-          case e: Exception => Logger.error(s"AccountController: closeAccount: An error occurred due to ${e.getMessage} returning internal server error")
+          case e: Exception => {
+            Logger.error(s"AccountController: closeAccount: An error occurred due to ${e.getMessage} returning internal server error")
             LisaMetrics.incrementMetrics(startTime,
               LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR, LisaMetricKeys.CLOSE))
             InternalServerError(Json.toJson(ErrorInternalServerError))
+          }
         }
       }
     }

--- a/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
@@ -266,7 +266,7 @@ class AccountController extends LisaController with LisaConstants {
       }
 
       def transferInDateError(request: CreateLisaAccountTransferRequest) = {
-        if (transferRequest.firstSubscriptionDate.isBefore(LISA_START_DATE)) {
+        if (transferRequest.transferAccount.transferInDate.isBefore(LISA_START_DATE)) {
           Some(ErrorValidation("INVALID_DATE", "The transferInDate cannot be before 6 April 2017", Some("/transferAccount/transferInDate")))
         }
         else {

--- a/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
@@ -36,469 +36,435 @@ class AccountController extends LisaController with LisaConstants {
   val service: AccountService = AccountService
   val auditService: AuditService = AuditService
 
-  def createOrTransferLisaAccount(lisaManager: String): Action[AnyContent] = validateAccept(acceptHeaderValidationRules).async { implicit request =>
-    implicit val startTime = System.currentTimeMillis()
-    LisaMetrics.startMetrics(startTime,LisaMetricKeys.ACCOUNT)
+  //region Create Or Transfer Account
 
-    withValidLMRN(lisaManager) {
-      withValidJson[CreateLisaAccountRequest](
-        (req) => {
-          req match {
-            case createRequest: CreateLisaAccountCreationRequest => {
-              if (hasAccountTransferData(request.body.asJson.get.as[JsObject])) {
-                LisaMetrics.startMetrics(System.currentTimeMillis(),
+    def createOrTransferLisaAccount(lisaManager: String): Action[AnyContent] = validateAccept(acceptHeaderValidationRules).async { implicit request =>
+      implicit val startTime = System.currentTimeMillis()
+      LisaMetrics.startMetrics(startTime,LisaMetricKeys.ACCOUNT)
+
+      withValidLMRN(lisaManager) {
+        withValidJson[CreateLisaAccountRequest](
+          (req) => {
+            req match {
+              case createRequest: CreateLisaAccountCreationRequest => {
+                if (hasAccountTransferData(request.body.asJson.get.as[JsObject])) {
+                  LisaMetrics.startMetrics(System.currentTimeMillis(),
+                    LisaMetricKeys.lisaError(FORBIDDEN,LisaMetricKeys.ACCOUNT))
+
+                  Future.successful(Forbidden(toJson(ErrorTransferAccountDataProvided)))
+                }
+                else {
+                  processAccountCreation(lisaManager, createRequest)
+                }
+              }
+              case transferRequest: CreateLisaAccountTransferRequest => processAccountTransfer(lisaManager, transferRequest)
+            }
+          },
+          Some(
+            (errors) => {
+              Logger.info("The errors are " + errors.toString())
+
+              val transferAccountDataNotProvided = errors.count {
+                case (path: JsPath, errors: Seq[ValidationError]) => {
+                  path.toString().contains("/transferAccount") && errors.contains(ValidationError("error.path.missing"))
+                }
+              }
+
+              if (transferAccountDataNotProvided > 0) {
+                LisaMetrics.incrementMetrics(startTime,
                   LisaMetricKeys.lisaError(FORBIDDEN,LisaMetricKeys.ACCOUNT))
 
-                Future.successful(Forbidden(toJson(ErrorTransferAccountDataProvided)))
+                Future.successful(Forbidden(toJson(ErrorTransferAccountDataNotProvided)))
               }
               else {
-                processAccountCreation(lisaManager, createRequest)
+                LisaMetrics.incrementMetrics(startTime,
+                  LisaMetricKeys.lisaError(BAD_REQUEST,LisaMetricKeys.ACCOUNT))
+
+                Future.successful(BadRequest(toJson(ErrorBadRequest(errorConverter.convert(errors)))))
               }
             }
-            case transferRequest: CreateLisaAccountTransferRequest => processAccountTransfer(lisaManager, transferRequest)
+          ), lisaManager = lisaManager
+        )
+      }
+    }
+
+    //region Create Account
+
+      private def hasAccountTransferData(js: JsObject): Boolean = {
+        js.keys.contains("transferAccount")
+      }
+
+      private def processAccountCreation(lisaManager: String, creationRequest: CreateLisaAccountCreationRequest)
+                                        (implicit hc: HeaderCarrier, startTime:Long) = {
+        val action = "Created"
+
+        hasValidSubscriptionDate(lisaManager, creationRequest) { () =>
+          service.createAccount(lisaManager, creationRequest).map { result =>
+            result match {
+              case CreateLisaAccountSuccessResponse(accountId) => {
+                auditService.audit(
+                  auditType = "accountCreated",
+                  path = getEndpointUrl(lisaManager),
+                  auditData = creationRequest.toStringMap + (ZREF -> lisaManager)
+                )
+                val data = ApiResponseData(message = "Account created", accountId = Some(accountId))
+                LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.ACCOUNT)
+
+                Created(Json.toJson(ApiResponse(data = Some(data), success = true, status = CREATED)))
+              }
+              case CreateLisaAccountInvestorNotFoundResponse =>
+                processCreateOrTransferFailure(lisaManager, creationRequest, ErrorInvestorNotFound, FORBIDDEN, action)
+              case CreateLisaAccountInvestorNotEligibleResponse =>
+                processCreateOrTransferFailure(lisaManager, creationRequest, ErrorInvestorNotEligible, FORBIDDEN, action)
+              case CreateLisaAccountInvestorComplianceCheckFailedResponse =>
+                processCreateOrTransferFailure(lisaManager, creationRequest, ErrorInvestorComplianceCheckFailedCreateTransfer, FORBIDDEN, action)
+              case CreateLisaAccountInvestorAccountAlreadyClosedResponse =>
+                processCreateOrTransferFailure(lisaManager, creationRequest, ErrorAccountAlreadyClosed, FORBIDDEN, action)
+              case CreateLisaAccountInvestorAccountAlreadyVoidResponse =>
+                processCreateOrTransferFailure(lisaManager, creationRequest, ErrorAccountAlreadyVoided, FORBIDDEN, action)
+              case CreateLisaAccountAlreadyExistsResponse =>
+                processCreateOrTransferFailure(lisaManager, creationRequest, ErrorAccountAlreadyExists(creationRequest.accountId), CONFLICT, action)
+              case _ => {
+                Logger.error(s"AccountController: createAccount unknown case from DES returning internal server error")
+                processCreateOrTransferFailure(lisaManager, creationRequest, ErrorInternalServerError, INTERNAL_SERVER_ERROR, action)
+              }
+            }
+          } recover {
+            case e: Exception => {
+              Logger.error(s"AccountController: An error occurred due to ${e.getMessage} returning internal server error")
+              processCreateOrTransferFailure(lisaManager, creationRequest, ErrorInternalServerError, INTERNAL_SERVER_ERROR, action)
+            }
           }
-        },
-        Some(
-          (errors) => {
-            Logger.info("The errors are " + errors.toString())
+        }
+      }
 
-            val transferAccountDataNotProvided = errors.count {
-              case (path: JsPath, errors: Seq[ValidationError]) => {
-                path.toString().contains("/transferAccount") && errors.contains(ValidationError("error.path.missing"))
+      private def hasValidSubscriptionDate(lisaManager: String, creationRequest: CreateLisaAccountCreationRequest)
+                                          (success: () => Future[Result])
+                                          (implicit hc: HeaderCarrier, startTime:Long): Future[Result] = {
+
+        if (creationRequest.firstSubscriptionDate.isBefore(LISA_START_DATE)) {
+          auditService.audit(
+            auditType = "accountNotCreated",
+            path = getEndpointUrl(lisaManager),
+            auditData = creationRequest.toStringMap ++ Map(ZREF -> lisaManager,
+              "reasonNotCreated" -> "FORBIDDEN")
+          )
+
+          LisaMetrics.incrementMetrics(System.currentTimeMillis(), LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
+
+          Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
+            ErrorValidation("INVALID_DATE", "The firstSubscriptionDate cannot be before 6 April 2017", Some("/firstSubscriptionDate"))
+          )))))
+        }
+        else {
+          success()
+        }
+      }
+
+    //endregion
+
+    //region Transfer Account
+
+      private def processAccountTransfer(lisaManager: String, transferRequest: CreateLisaAccountTransferRequest)
+                                        (implicit hc: HeaderCarrier, startTime:Long) = {
+        val action = "Transferred"
+
+        hasValidTransferDates(lisaManager, transferRequest){ () =>
+          service.transferAccount(lisaManager, transferRequest).map { result =>
+            result match {
+              case CreateLisaAccountSuccessResponse(accountId) => {
+                auditService.audit(
+                  auditType = "accountTransferred",
+                  path = getEndpointUrl(lisaManager),
+                  auditData = transferRequest.toStringMap + (ZREF -> lisaManager)
+                )
+                val data = ApiResponseData(message = "Account transferred", accountId = Some(accountId))
+                LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.ACCOUNT)
+
+                Created(Json.toJson(ApiResponse(data = Some(data), success = true, status = 201)))
+              }
+              case CreateLisaAccountInvestorNotFoundResponse =>
+                processCreateOrTransferFailure(lisaManager, transferRequest, ErrorInvestorNotFound, FORBIDDEN, action)
+              case CreateLisaAccountInvestorComplianceCheckFailedResponse =>
+                processCreateOrTransferFailure(lisaManager, transferRequest, ErrorInvestorComplianceCheckFailedCreateTransfer, FORBIDDEN, action)
+              case CreateLisaAccountInvestorPreviousAccountDoesNotExistResponse =>
+                processCreateOrTransferFailure(lisaManager, transferRequest, ErrorPreviousAccountDoesNotExist, FORBIDDEN, action)
+              case CreateLisaAccountInvestorAccountAlreadyClosedResponse =>
+                processCreateOrTransferFailure(lisaManager, transferRequest, ErrorAccountAlreadyClosed, FORBIDDEN, action)
+              case CreateLisaAccountInvestorAccountAlreadyVoidResponse =>
+                processCreateOrTransferFailure(lisaManager, transferRequest, ErrorAccountAlreadyVoided, FORBIDDEN, action)
+              case CreateLisaAccountAlreadyExistsResponse =>
+                processCreateOrTransferFailure(lisaManager, transferRequest, ErrorAccountAlreadyExists(transferRequest.accountId), CONFLICT, action)
+              case _ => {
+                Logger.error(s"AccountController: transferAccount unknown case from DES returning internal server error")
+                processCreateOrTransferFailure(lisaManager, transferRequest, ErrorInternalServerError, INTERNAL_SERVER_ERROR, action)
               }
             }
+          } recover {
+            case e: Exception => {
+              Logger.error(s"AccountController: An error occurred in due to ${e.getMessage} returning internal server error")
+              processCreateOrTransferFailure(lisaManager, transferRequest, ErrorInternalServerError, INTERNAL_SERVER_ERROR, action)
+            }
+          }
+        }
+      }
 
-            if (transferAccountDataNotProvided > 0) {
-              LisaMetrics.incrementMetrics(startTime,
-                LisaMetricKeys.lisaError(FORBIDDEN,LisaMetricKeys.ACCOUNT))
+      private def hasValidTransferDates(lisaManager: String, transferRequest: CreateLisaAccountTransferRequest)
+                                       (success: () => Future[Result])
+                                       (implicit hc: HeaderCarrier, startTime:Long): Future[Result] = {
 
-              Future.successful(Forbidden(toJson(ErrorTransferAccountDataNotProvided)))
+        if (
+          transferRequest.firstSubscriptionDate.isBefore(LISA_START_DATE) ||
+            transferRequest.transferAccount.transferInDate.isBefore(LISA_START_DATE)) {
+
+          def firstSubscriptionDateError(request: CreateLisaAccountTransferRequest) = {
+            if (transferRequest.firstSubscriptionDate.isBefore(LISA_START_DATE)) {
+              Some(ErrorValidation("INVALID_DATE", "The firstSubscriptionDate cannot be before 6 April 2017", Some("/firstSubscriptionDate")))
             }
             else {
-              LisaMetrics.incrementMetrics(startTime,
-                LisaMetricKeys.lisaError(BAD_REQUEST,LisaMetricKeys.ACCOUNT))
-
-              Future.successful(BadRequest(toJson(ErrorBadRequest(errorConverter.convert(errors)))))
+              None
             }
           }
-        ), lisaManager = lisaManager
-      )
-    }
-  }
 
-  def getAccountDetails (lisaManager: String, accountId: String): Action[AnyContent] = validateAccept(acceptHeaderValidationRules).async { implicit request =>
-    implicit val startTime = System.currentTimeMillis()
-    LisaMetrics.startMetrics(startTime, LisaMetricKeys.ACCOUNT)
-    withValidLMRN(lisaManager) {
-      withValidAccountId(accountId) {
-        processGetAccountDetails(lisaManager, accountId)
-      }
-    }
-  }
-
-  def closeLisaAccount(lisaManager: String, accountId: String): Action[AnyContent] = validateAccept(acceptHeaderValidationRules).async { implicit request =>
-    withValidLMRN(lisaManager) {
-      withValidJson[CloseLisaAccountRequest]( closeRequest =>
-        {
-            implicit val startTime = System.currentTimeMillis()
-            LisaMetrics.startMetrics(startTime,LisaMetricKeys.CLOSE)
-            processAccountClosure(lisaManager, accountId, closeRequest)
-        }, lisaManager = lisaManager
-      )
-    }
-  }
-
-  private def processGetAccountDetails(lisaManager:String, accountId:String)(implicit hc: HeaderCarrier,startTime:Long) = {
-    service.getAccount(lisaManager, accountId).map { result =>
-      result match {
-        case response : GetLisaAccountSuccessResponse  => {
-          LisaMetrics.incrementMetrics(startTime,LisaMetricKeys.ACCOUNT)
-          Ok(Json.toJson(response))
-        }
-
-        case GetLisaAccountDoesNotExistResponse => {
-          LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-            LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
-          NotFound(Json.toJson(ErrorAccountNotFound))
-        }
-
-        case _ => {
-          LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-            LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
-          InternalServerError(Json.toJson(ErrorInternalServerError))
-        }
-      }
-    }
-  }
-
-  private def returnCreationFailure(lisaManager: String,
-                                    creationRequest: CreateLisaAccountCreationRequest,
-                                    e: ErrorResponse, status: Int)
-                                   (implicit hc: HeaderCarrier, startTime:Long) = {
-    auditService.audit(
-      auditType = "accountNotCreated",
-      path = getEndpointUrl(lisaManager),
-      auditData = creationRequest.toStringMap ++ Map(ZREF -> lisaManager, "reasonNotCreated" -> e.errorCode)
-    )
-
-    LisaMetrics.incrementMetrics(System.currentTimeMillis(), LisaMetricKeys.lisaError(status, LisaMetricKeys.ACCOUNT))
-
-    Status(status).apply(Json.toJson(e))
-  }
-
-  private def hasValidSubscriptionDate(lisaManager: String, creationRequest: CreateLisaAccountCreationRequest)
-                                      (success: () => Future[Result])
-                                      (implicit hc: HeaderCarrier, startTime:Long): Future[Result] = {
-
-    if (creationRequest.firstSubscriptionDate.isBefore(LISA_START_DATE)) {
-      auditService.audit(
-        auditType = "accountNotCreated",
-        path = getEndpointUrl(lisaManager),
-        auditData = creationRequest.toStringMap ++ Map(ZREF -> lisaManager,
-          "reasonNotCreated" -> "FORBIDDEN")
-      )
-
-      LisaMetrics.incrementMetrics(System.currentTimeMillis(), LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
-
-      Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
-        ErrorValidation("INVALID_DATE", "The firstSubscriptionDate cannot be before 6 April 2017", Some("/firstSubscriptionDate"))
-      )))))
-    }
-    else {
-      success()
-    }
-  }
-
-  private def processAccountCreation(lisaManager: String, creationRequest: CreateLisaAccountCreationRequest)
-                                    (implicit hc: HeaderCarrier, startTime:Long) = {
-
-    hasValidSubscriptionDate(lisaManager, creationRequest) { () =>
-      service.createAccount(lisaManager, creationRequest).map { result =>
-        result match {
-          case CreateLisaAccountSuccessResponse(accountId) => {
-            auditService.audit(
-              auditType = "accountCreated",
-              path = getEndpointUrl(lisaManager),
-              auditData = creationRequest.toStringMap + (ZREF -> lisaManager)
-            )
-            val data = ApiResponseData(message = "Account created", accountId = Some(accountId))
-            LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.ACCOUNT)
-
-            Created(Json.toJson(ApiResponse(data = Some(data), success = true, status = CREATED)))
+          def transferInDateError(request: CreateLisaAccountTransferRequest) = {
+            if (transferRequest.transferAccount.transferInDate.isBefore(LISA_START_DATE)) {
+              Some(ErrorValidation("INVALID_DATE", "The transferInDate cannot be before 6 April 2017", Some("/transferAccount/transferInDate")))
+            }
+            else {
+              None
+            }
           }
-          case CreateLisaAccountInvestorNotFoundResponse =>
-            returnCreationFailure(lisaManager, creationRequest, ErrorInvestorNotFound, FORBIDDEN)
-          case CreateLisaAccountInvestorNotEligibleResponse =>
-            returnCreationFailure(lisaManager, creationRequest, ErrorInvestorNotEligible, FORBIDDEN)
-          case CreateLisaAccountInvestorComplianceCheckFailedResponse =>
-            returnCreationFailure(lisaManager, creationRequest, ErrorInvestorComplianceCheckFailedCreateTransfer, FORBIDDEN)
-          case CreateLisaAccountInvestorAccountAlreadyClosedResponse =>
-            returnCreationFailure(lisaManager, creationRequest, ErrorAccountAlreadyClosed, FORBIDDEN)
-          case CreateLisaAccountInvestorAccountAlreadyVoidResponse =>
-            returnCreationFailure(lisaManager, creationRequest, ErrorAccountAlreadyVoided, FORBIDDEN)
-          case CreateLisaAccountAlreadyExistsResponse =>
-            returnCreationFailure(lisaManager, creationRequest, ErrorAccountAlreadyExists(creationRequest.accountId), CONFLICT)
-          case _ => {
-            Logger.error(s"AccountController: createAccount unknown case from DES returning internal server error")
-            returnCreationFailure(lisaManager, creationRequest, ErrorInternalServerError, INTERNAL_SERVER_ERROR)
-          }
-        }
-      } recover {
-        case e: Exception => {
-          Logger.error(s"AccountController: An error occurred due to ${e.getMessage} returning internal server error")
-          returnCreationFailure(lisaManager, creationRequest, ErrorInternalServerError, INTERNAL_SERVER_ERROR)
-        }
-      }
-    }
-  }
 
-  private def processAccountTransfer(lisaManager: String, transferRequest: CreateLisaAccountTransferRequest)(implicit hc: HeaderCarrier,startTime:Long) = {
-    if (
-      transferRequest.firstSubscriptionDate.isBefore(LISA_START_DATE) ||
-      transferRequest.transferAccount.transferInDate.isBefore(LISA_START_DATE)) {
+          val errors = List(firstSubscriptionDateError(transferRequest), transferInDateError(transferRequest)).
+            filter(_.isDefined).
+            map(_.get)
 
-      def firstSubscriptionDateError(request: CreateLisaAccountTransferRequest) = {
-        if (transferRequest.firstSubscriptionDate.isBefore(LISA_START_DATE)) {
-          Some(ErrorValidation("INVALID_DATE", "The firstSubscriptionDate cannot be before 6 April 2017", Some("/firstSubscriptionDate")))
+          auditService.audit(
+            auditType = "accountNotTransferred",
+            path = getEndpointUrl(lisaManager),
+            auditData = transferRequest.toStringMap ++ Map(ZREF -> lisaManager,
+              "reasonNotCreated" -> "FORBIDDEN")
+          )
+
+          LisaMetrics.incrementMetrics(System.currentTimeMillis(), LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
+
+          Future.successful(Forbidden(Json.toJson(ErrorForbidden(errors))))
         }
         else {
-          None
+          success()
         }
       }
 
-      def transferInDateError(request: CreateLisaAccountTransferRequest) = {
-        if (transferRequest.transferAccount.transferInDate.isBefore(LISA_START_DATE)) {
-          Some(ErrorValidation("INVALID_DATE", "The transferInDate cannot be before 6 April 2017", Some("/transferAccount/transferInDate")))
-        }
-        else {
-          None
-        }
-      }
+    //endregion
 
-      val errors = List(firstSubscriptionDateError(transferRequest), transferInDateError(transferRequest)).
-                    filter(_.isDefined).
-                    map(_.get)
-
+    private def processCreateOrTransferFailure(lisaManager: String,
+                                              requestData: Product,
+                                              e: ErrorResponse,
+                                              status: Int,
+                                              action: String)
+                                             (implicit hc: HeaderCarrier, startTime:Long) = {
       auditService.audit(
-        auditType = "accountNotTransferred",
+        auditType = s"accountNot$action",
         path = getEndpointUrl(lisaManager),
-        auditData = transferRequest.toStringMap ++ Map(ZREF -> lisaManager,
-          "reasonNotCreated" -> "FORBIDDEN")
+        auditData = requestData.toStringMap ++ Map(
+          ZREF -> lisaManager,
+          s"reasonNotCreated" -> e.errorCode
+        )
       )
 
-      LisaMetrics.incrementMetrics(System.currentTimeMillis(), LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
+      LisaMetrics.incrementMetrics(System.currentTimeMillis(),
+        LisaMetricKeys.lisaError(status, LisaMetricKeys.ACCOUNT))
 
-      Future.successful(Forbidden(Json.toJson(ErrorForbidden(errors))))
+      Status(status).apply(Json.toJson(e))
     }
-    else {
-      service.transferAccount(lisaManager, transferRequest).map { result =>
-        result match {
-          case CreateLisaAccountSuccessResponse(accountId) => {
-            auditService.audit(
-              auditType = "accountTransferred",
-              path = getEndpointUrl(lisaManager),
-              auditData = transferRequest.toStringMap + (ZREF -> lisaManager)
-            )
-            val data = ApiResponseData(message = "Account transferred", accountId = Some(accountId))
-            LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.ACCOUNT)
 
-            Created(Json.toJson(ApiResponse(data = Some(data), success = true, status = 201)))
-          }
-          case CreateLisaAccountInvestorNotFoundResponse => {
-            auditService.audit(
-              auditType = "accountNotTransferred",
-              path = getEndpointUrl(lisaManager),
-              auditData = transferRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "reasonNotCreated" -> ErrorInvestorNotFound.errorCode)
-            )
-            LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
-
-            Forbidden(Json.toJson(ErrorInvestorNotFound))
-          }
-          case CreateLisaAccountInvestorComplianceCheckFailedResponse => {
-            auditService.audit(
-              auditType = "accountNotTransferred",
-              path = getEndpointUrl(lisaManager),
-              auditData = transferRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "reasonNotCreated" -> ErrorInvestorComplianceCheckFailedCreateTransfer.errorCode)
-            )
-            LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
-
-            Forbidden(Json.toJson(ErrorInvestorComplianceCheckFailedCreateTransfer))
-          }
-          case CreateLisaAccountInvestorPreviousAccountDoesNotExistResponse => {
-            auditService.audit(
-              auditType = "accountNotTransferred",
-              path = getEndpointUrl(lisaManager),
-              auditData = transferRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "reasonNotCreated" -> ErrorPreviousAccountDoesNotExist.errorCode)
-            )
-            LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
-
-            Forbidden(Json.toJson(ErrorPreviousAccountDoesNotExist))
-          }
-          case CreateLisaAccountInvestorAccountAlreadyClosedResponse => {
-            auditService.audit(
-              auditType = "accountNotTransferred",
-              path = getEndpointUrl(lisaManager),
-              auditData = transferRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "reasonNotCreated" -> ErrorAccountAlreadyClosed.errorCode)
-            )
-            LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
-
-            Forbidden(Json.toJson(ErrorAccountAlreadyClosed))
-          }
-          case CreateLisaAccountInvestorAccountAlreadyVoidResponse => {
-            auditService.audit(
-              auditType = "accountNotTransferred",
-              path = getEndpointUrl(lisaManager),
-              auditData = transferRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "reasonNotCreated" -> ErrorAccountAlreadyVoided.errorCode)
-            )
-            LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
-
-            Forbidden(Json.toJson(ErrorAccountAlreadyVoided))
-          }
-          case CreateLisaAccountAlreadyExistsResponse => {
-            val result = ErrorAccountAlreadyExists(transferRequest.accountId)
-            auditService.audit(
-              auditType = "accountNotTransferred",
-              path = getEndpointUrl(lisaManager),
-              auditData = transferRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "reasonNotCreated" -> result.errorCode)
-            )
-            LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-              LisaMetricKeys.lisaError(CONFLICT, LisaMetricKeys.ACCOUNT))
-
-            Conflict(Json.toJson(result))
-          }
-          case _ => {
-            auditService.audit(
-              auditType = "accountNotTransferred",
-              path = getEndpointUrl(lisaManager),
-              auditData = transferRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "reasonNotCreated" -> ErrorInternalServerError.errorCode)
-            )
-            Logger.error(s"AccountController: transferAccount unknown case from DES returning internal server error")
-            LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-              LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR, LisaMetricKeys.ACCOUNT))
-
-            InternalServerError(Json.toJson(ErrorInternalServerError))
-          }
-        }
-      } recover {
-        case e: Exception => {
-          Logger.error(s"AccountController: An error occurred in due to ${e.getMessage} returning internal server error")
-
-          LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-            LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR, LisaMetricKeys.ACCOUNT))
-
-          InternalServerError(Json.toJson(ErrorInternalServerError))
-        }
-      }
-    }
-  }
-
-  private def processAccountClosure(lisaManager: String, accountId: String, closeLisaAccountRequest: CloseLisaAccountRequest)(implicit hc: HeaderCarrier, startTime:Long) = {
-    if (closeLisaAccountRequest.closureDate.isBefore(LISA_START_DATE)) {
-      auditService.audit(
-        auditType = "accountNotClosed",
-        path = getCloseEndpointUrl(lisaManager, accountId),
-        auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-          "accountId" -> accountId,
-          "reasonNotClosed" -> "FORBIDDEN")
-      )
-
-      LisaMetrics.incrementMetrics(System.currentTimeMillis(), LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
-
-      Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
-        ErrorValidation("INVALID_DATE", "The closureDate cannot be before 6 April 2017", Some("/closureDate"))
-      )))))
-    }
-    else {
-      service.closeAccount(lisaManager, accountId, closeLisaAccountRequest).map { result =>
-        result match {
-          case CloseLisaAccountSuccessResponse(accountId) => {
-            LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.CLOSE)
-
-            auditService.audit(
-              auditType = "accountClosed",
-              path = getCloseEndpointUrl(lisaManager, accountId),
-              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "accountId" -> accountId)
-            )
-
-            val data = ApiResponseData(message = "LISA account closed", accountId = Some(accountId))
-
-            Ok(Json.toJson(ApiResponse(data = Some(data), success = true, status = 200)))
-          }
-          case CloseLisaAccountAlreadyVoidResponse => {
-            auditService.audit(
-              auditType = "accountNotClosed",
-              path = getCloseEndpointUrl(lisaManager, accountId),
-              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "accountId" -> accountId,
-                "reasonNotClosed" -> ErrorAccountAlreadyVoided.errorCode)
-            )
-            LisaMetrics.incrementMetrics(startTime,
-              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
-
-            Forbidden(Json.toJson(ErrorAccountAlreadyVoided))
-          }
-          case CloseLisaAccountAlreadyClosedResponse => {
-            auditService.audit(
-              auditType = "accountNotClosed",
-              path = getCloseEndpointUrl(lisaManager, accountId),
-              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "accountId" -> accountId,
-                "reasonNotClosed" -> ErrorAccountAlreadyClosed.errorCode)
-            )
-            LisaMetrics.incrementMetrics(startTime,
-              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
-
-            Forbidden(Json.toJson(ErrorAccountAlreadyClosed))
-          }
-          case CloseLisaAccountCancellationPeriodExceeded => {
-            auditService.audit(
-              auditType = "accountNotClosed",
-              path = getCloseEndpointUrl(lisaManager, accountId),
-              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "accountId" -> accountId,
-                "reasonNotClosed" -> ErrorAccountCancellationPeriodExceeded.errorCode)
-            )
-            LisaMetrics.incrementMetrics(startTime,
-              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
-
-            Forbidden(Json.toJson(ErrorAccountCancellationPeriodExceeded))
-          }
-          case CloseLisaAccountWithinCancellationPeriod => {
-            auditService.audit(
-              auditType = "accountNotClosed",
-              path = getCloseEndpointUrl(lisaManager, accountId),
-              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "accountId" -> accountId,
-                "reasonNotClosed" -> ErrorAccountWithinCancellationPeriod.errorCode)
-            )
-            LisaMetrics.incrementMetrics(startTime,
-              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
-
-            Forbidden(Json.toJson(ErrorAccountWithinCancellationPeriod))
-          }
-          case CloseLisaAccountNotFoundResponse => {
-            auditService.audit(
-              auditType = "accountNotClosed",
-              path = getCloseEndpointUrl(lisaManager, accountId),
-              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "accountId" -> accountId,
-                "reasonNotClosed" -> ErrorAccountNotFound.errorCode)
-            )
-            LisaMetrics.incrementMetrics(startTime,
-              LisaMetricKeys.lisaError(NOT_FOUND, LisaMetricKeys.CLOSE))
-
-            NotFound(Json.toJson(ErrorAccountNotFound))
-          }
-          case _ => {
-            auditService.audit(
-              auditType = "accountNotClosed",
-              path = getCloseEndpointUrl(lisaManager, accountId),
-              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-                "accountId" -> accountId,
-                "reasonNotClosed" -> ErrorInternalServerError.errorCode)
-            )
-            Logger.error(s"AccountController: closeAccount unknown case from DES returning internal server error")
-            LisaMetrics.incrementMetrics(startTime,
-              LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR, LisaMetricKeys.CLOSE))
-
-            InternalServerError(Json.toJson(ErrorInternalServerError))
-          }
-        }
-      } recover {
-        case e: Exception => Logger.error(s"AccountController: closeAccount: An error occurred due to ${e.getMessage} returning internal server error")
-          LisaMetrics.incrementMetrics(startTime,
-            LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR, LisaMetricKeys.CLOSE))
-          InternalServerError(Json.toJson(ErrorInternalServerError))
-      }
-    }
-  }
-
-  private def hasAccountTransferData(js: JsObject): Boolean = {
-    js.keys.contains("transferAccount")
-  }
-
-  private def getEndpointUrl(lisaManagerReferenceNumber: String): String = {
+    private def getEndpointUrl(lisaManagerReferenceNumber: String): String = {
     s"/manager/$lisaManagerReferenceNumber/accounts"
   }
 
-  private def getAccountDetailsEndpointUrl(lisaManagerReferenceNumber: String, accountId: String): String = {
-    s"/manager/$lisaManagerReferenceNumber/accounts/$accountId"
-  }
+  //endregion
 
-  private def getCloseEndpointUrl(lisaManagerReferenceNumber: String, accountID: String): String = {
-    s"/manager/$lisaManagerReferenceNumber/accounts/$accountID/close-account"
-  }
+  //region Get Account
+
+    def getAccountDetails (lisaManager: String, accountId: String): Action[AnyContent] = validateAccept(acceptHeaderValidationRules).async { implicit request =>
+      implicit val startTime = System.currentTimeMillis()
+      LisaMetrics.startMetrics(startTime, LisaMetricKeys.ACCOUNT)
+      withValidLMRN(lisaManager) {
+        withValidAccountId(accountId) {
+          processGetAccountDetails(lisaManager, accountId)
+        }
+      }
+    }
+
+    private def processGetAccountDetails(lisaManager:String, accountId:String)(implicit hc: HeaderCarrier,startTime:Long) = {
+      service.getAccount(lisaManager, accountId).map { result =>
+        result match {
+          case response : GetLisaAccountSuccessResponse  => {
+            LisaMetrics.incrementMetrics(startTime,LisaMetricKeys.ACCOUNT)
+            Ok(Json.toJson(response))
+          }
+
+          case GetLisaAccountDoesNotExistResponse => {
+            LisaMetrics.incrementMetrics(System.currentTimeMillis(),
+              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
+            NotFound(Json.toJson(ErrorAccountNotFound))
+          }
+
+          case _ => {
+            LisaMetrics.incrementMetrics(System.currentTimeMillis(),
+              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.ACCOUNT))
+            InternalServerError(Json.toJson(ErrorInternalServerError))
+          }
+        }
+      }
+    }
+
+    private def getAccountDetailsEndpointUrl(lisaManagerReferenceNumber: String, accountId: String): String = {
+      s"/manager/$lisaManagerReferenceNumber/accounts/$accountId"
+    }
+
+  //endregion
+
+  //region Close Account
+
+    def closeLisaAccount(lisaManager: String, accountId: String): Action[AnyContent] = validateAccept(acceptHeaderValidationRules).async { implicit request =>
+      withValidLMRN(lisaManager) {
+        withValidJson[CloseLisaAccountRequest]( closeRequest =>
+          {
+              implicit val startTime = System.currentTimeMillis()
+              LisaMetrics.startMetrics(startTime,LisaMetricKeys.CLOSE)
+              processAccountClosure(lisaManager, accountId, closeRequest)
+          }, lisaManager = lisaManager
+        )
+      }
+    }
+
+    private def processAccountClosure(lisaManager: String, accountId: String, closeLisaAccountRequest: CloseLisaAccountRequest)(implicit hc: HeaderCarrier, startTime:Long) = {
+      if (closeLisaAccountRequest.closureDate.isBefore(LISA_START_DATE)) {
+        auditService.audit(
+          auditType = "accountNotClosed",
+          path = getCloseEndpointUrl(lisaManager, accountId),
+          auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+            "accountId" -> accountId,
+            "reasonNotClosed" -> "FORBIDDEN")
+        )
+
+        LisaMetrics.incrementMetrics(System.currentTimeMillis(), LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
+
+        Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
+          ErrorValidation("INVALID_DATE", "The closureDate cannot be before 6 April 2017", Some("/closureDate"))
+        )))))
+      }
+      else {
+        service.closeAccount(lisaManager, accountId, closeLisaAccountRequest).map { result =>
+          result match {
+            case CloseLisaAccountSuccessResponse(accountId) => {
+              LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.CLOSE)
+
+              auditService.audit(
+                auditType = "accountClosed",
+                path = getCloseEndpointUrl(lisaManager, accountId),
+                auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                  "accountId" -> accountId)
+              )
+
+              val data = ApiResponseData(message = "LISA account closed", accountId = Some(accountId))
+
+              Ok(Json.toJson(ApiResponse(data = Some(data), success = true, status = 200)))
+            }
+            case CloseLisaAccountAlreadyVoidResponse => {
+              auditService.audit(
+                auditType = "accountNotClosed",
+                path = getCloseEndpointUrl(lisaManager, accountId),
+                auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                  "accountId" -> accountId,
+                  "reasonNotClosed" -> ErrorAccountAlreadyVoided.errorCode)
+              )
+              LisaMetrics.incrementMetrics(startTime,
+                LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
+
+              Forbidden(Json.toJson(ErrorAccountAlreadyVoided))
+            }
+            case CloseLisaAccountAlreadyClosedResponse => {
+              auditService.audit(
+                auditType = "accountNotClosed",
+                path = getCloseEndpointUrl(lisaManager, accountId),
+                auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                  "accountId" -> accountId,
+                  "reasonNotClosed" -> ErrorAccountAlreadyClosed.errorCode)
+              )
+              LisaMetrics.incrementMetrics(startTime,
+                LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
+
+              Forbidden(Json.toJson(ErrorAccountAlreadyClosed))
+            }
+            case CloseLisaAccountCancellationPeriodExceeded => {
+              auditService.audit(
+                auditType = "accountNotClosed",
+                path = getCloseEndpointUrl(lisaManager, accountId),
+                auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                  "accountId" -> accountId,
+                  "reasonNotClosed" -> ErrorAccountCancellationPeriodExceeded.errorCode)
+              )
+              LisaMetrics.incrementMetrics(startTime,
+                LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
+
+              Forbidden(Json.toJson(ErrorAccountCancellationPeriodExceeded))
+            }
+            case CloseLisaAccountWithinCancellationPeriod => {
+              auditService.audit(
+                auditType = "accountNotClosed",
+                path = getCloseEndpointUrl(lisaManager, accountId),
+                auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                  "accountId" -> accountId,
+                  "reasonNotClosed" -> ErrorAccountWithinCancellationPeriod.errorCode)
+              )
+              LisaMetrics.incrementMetrics(startTime,
+                LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
+
+              Forbidden(Json.toJson(ErrorAccountWithinCancellationPeriod))
+            }
+            case CloseLisaAccountNotFoundResponse => {
+              auditService.audit(
+                auditType = "accountNotClosed",
+                path = getCloseEndpointUrl(lisaManager, accountId),
+                auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                  "accountId" -> accountId,
+                  "reasonNotClosed" -> ErrorAccountNotFound.errorCode)
+              )
+              LisaMetrics.incrementMetrics(startTime,
+                LisaMetricKeys.lisaError(NOT_FOUND, LisaMetricKeys.CLOSE))
+
+              NotFound(Json.toJson(ErrorAccountNotFound))
+            }
+            case _ => {
+              auditService.audit(
+                auditType = "accountNotClosed",
+                path = getCloseEndpointUrl(lisaManager, accountId),
+                auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                  "accountId" -> accountId,
+                  "reasonNotClosed" -> ErrorInternalServerError.errorCode)
+              )
+              Logger.error(s"AccountController: closeAccount unknown case from DES returning internal server error")
+              LisaMetrics.incrementMetrics(startTime,
+                LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR, LisaMetricKeys.CLOSE))
+
+              InternalServerError(Json.toJson(ErrorInternalServerError))
+            }
+          }
+        } recover {
+          case e: Exception => Logger.error(s"AccountController: closeAccount: An error occurred due to ${e.getMessage} returning internal server error")
+            LisaMetrics.incrementMetrics(startTime,
+              LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR, LisaMetricKeys.CLOSE))
+            InternalServerError(Json.toJson(ErrorInternalServerError))
+        }
+      }
+    }
+
+    private def getCloseEndpointUrl(lisaManagerReferenceNumber: String, accountID: String): String = {
+      s"/manager/$lisaManagerReferenceNumber/accounts/$accountID/close-account"
+    }
+
+  //endregion
+
 }

--- a/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
@@ -138,11 +138,10 @@ class AccountController extends LisaController with LisaConstants {
     auditService.audit(
       auditType = "accountNotCreated",
       path = getEndpointUrl(lisaManager),
-      auditData = creationRequest.toStringMap ++ Map(ZREF -> lisaManager,
-        "reasonNotCreated" -> e.errorCode)
+      auditData = creationRequest.toStringMap ++ Map(ZREF -> lisaManager, "reasonNotCreated" -> e.errorCode)
     )
-    LisaMetrics.incrementMetrics(System.currentTimeMillis(),
-      LisaMetricKeys.lisaError(status, LisaMetricKeys.ACCOUNT))
+
+    LisaMetrics.incrementMetrics(System.currentTimeMillis(), LisaMetricKeys.lisaError(status, LisaMetricKeys.ACCOUNT))
 
     Status(status).apply(Json.toJson(e))
   }

--- a/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/AccountController.scala
@@ -395,108 +395,115 @@ class AccountController extends LisaController with LisaConstants {
   }
 
   private def processAccountClosure(lisaManager: String, accountId: String, closeLisaAccountRequest: CloseLisaAccountRequest)(implicit hc: HeaderCarrier, startTime:Long) = {
-    service.closeAccount(lisaManager, accountId, closeLisaAccountRequest).map { result =>
-      result match {
-        case CloseLisaAccountSuccessResponse(accountId) => {
-          LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.CLOSE)
+    if (closeLisaAccountRequest.closureDate.isBefore(LISA_START_DATE)) {
+      Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
+        ErrorValidation("INVALID_DATE", "The closureDate cannot be before 6 April 2017", Some("/closureDate"))
+      )))))
+    }
+    else {
+      service.closeAccount(lisaManager, accountId, closeLisaAccountRequest).map { result =>
+        result match {
+          case CloseLisaAccountSuccessResponse(accountId) => {
+            LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.CLOSE)
 
-          auditService.audit(
-            auditType = "accountClosed",
-            path = getCloseEndpointUrl(lisaManager, accountId),
-            auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-              "accountId" -> accountId)
-          )
+            auditService.audit(
+              auditType = "accountClosed",
+              path = getCloseEndpointUrl(lisaManager, accountId),
+              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                "accountId" -> accountId)
+            )
 
-          val data = ApiResponseData(message = "LISA account closed", accountId = Some(accountId))
+            val data = ApiResponseData(message = "LISA account closed", accountId = Some(accountId))
 
-          Ok(Json.toJson(ApiResponse(data = Some(data), success = true, status = 200)))
+            Ok(Json.toJson(ApiResponse(data = Some(data), success = true, status = 200)))
+          }
+          case CloseLisaAccountAlreadyVoidResponse => {
+            auditService.audit(
+              auditType = "accountNotClosed",
+              path = getCloseEndpointUrl(lisaManager, accountId),
+              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                "accountId" -> accountId,
+                "reasonNotClosed" -> ErrorAccountAlreadyVoided.errorCode)
+            )
+            LisaMetrics.incrementMetrics(startTime,
+              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
+
+            Forbidden(Json.toJson(ErrorAccountAlreadyVoided))
+          }
+          case CloseLisaAccountAlreadyClosedResponse => {
+            auditService.audit(
+              auditType = "accountNotClosed",
+              path = getCloseEndpointUrl(lisaManager, accountId),
+              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                "accountId" -> accountId,
+                "reasonNotClosed" -> ErrorAccountAlreadyClosed.errorCode)
+            )
+            LisaMetrics.incrementMetrics(startTime,
+              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
+
+            Forbidden(Json.toJson(ErrorAccountAlreadyClosed))
+          }
+          case CloseLisaAccountCancellationPeriodExceeded => {
+            auditService.audit(
+              auditType = "accountNotClosed",
+              path = getCloseEndpointUrl(lisaManager, accountId),
+              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                "accountId" -> accountId,
+                "reasonNotClosed" -> ErrorAccountCancellationPeriodExceeded.errorCode)
+            )
+            LisaMetrics.incrementMetrics(startTime,
+              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
+
+            Forbidden(Json.toJson(ErrorAccountCancellationPeriodExceeded))
+          }
+          case CloseLisaAccountWithinCancellationPeriod => {
+            auditService.audit(
+              auditType = "accountNotClosed",
+              path = getCloseEndpointUrl(lisaManager, accountId),
+              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                "accountId" -> accountId,
+                "reasonNotClosed" -> ErrorAccountWithinCancellationPeriod.errorCode)
+            )
+            LisaMetrics.incrementMetrics(startTime,
+              LisaMetricKeys.lisaError(FORBIDDEN, LisaMetricKeys.CLOSE))
+
+            Forbidden(Json.toJson(ErrorAccountWithinCancellationPeriod))
+          }
+          case CloseLisaAccountNotFoundResponse => {
+            auditService.audit(
+              auditType = "accountNotClosed",
+              path = getCloseEndpointUrl(lisaManager, accountId),
+              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                "accountId" -> accountId,
+                "reasonNotClosed" -> ErrorAccountNotFound.errorCode)
+            )
+            LisaMetrics.incrementMetrics(startTime,
+              LisaMetricKeys.lisaError(NOT_FOUND, LisaMetricKeys.CLOSE))
+
+            NotFound(Json.toJson(ErrorAccountNotFound))
+          }
+          case _ => {
+            auditService.audit(
+              auditType = "accountNotClosed",
+              path = getCloseEndpointUrl(lisaManager, accountId),
+              auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
+                "accountId" -> accountId,
+                "reasonNotClosed" -> ErrorInternalServerError.errorCode)
+            )
+            Logger.error(s"AccountController: closeAccount unknown case from DES returning internal server error")
+            LisaMetrics.incrementMetrics(startTime,
+              LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR, LisaMetricKeys.CLOSE))
+
+            InternalServerError(Json.toJson(ErrorInternalServerError))
+          }
         }
-        case CloseLisaAccountAlreadyVoidResponse => {
-          auditService.audit(
-            auditType = "accountNotClosed",
-            path = getCloseEndpointUrl(lisaManager, accountId),
-            auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-              "accountId" -> accountId,
-              "reasonNotClosed" -> ErrorAccountAlreadyVoided.errorCode)
-          )
+      } recover {
+        case e: Exception => Logger.error(s"AccountController: closeAccount: An error occurred due to ${e.getMessage} returning internal server error")
           LisaMetrics.incrementMetrics(startTime,
-            LisaMetricKeys.lisaError(FORBIDDEN,LisaMetricKeys.CLOSE))
-
-          Forbidden(Json.toJson(ErrorAccountAlreadyVoided))
-        }
-        case CloseLisaAccountAlreadyClosedResponse => {
-          auditService.audit(
-            auditType = "accountNotClosed",
-            path = getCloseEndpointUrl(lisaManager, accountId),
-            auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-              "accountId" -> accountId,
-              "reasonNotClosed" -> ErrorAccountAlreadyClosed.errorCode)
-          )
-          LisaMetrics.incrementMetrics(startTime,
-            LisaMetricKeys.lisaError(FORBIDDEN,LisaMetricKeys.CLOSE))
-
-          Forbidden(Json.toJson(ErrorAccountAlreadyClosed))
-        }
-        case CloseLisaAccountCancellationPeriodExceeded => {
-          auditService.audit(
-            auditType = "accountNotClosed",
-            path = getCloseEndpointUrl(lisaManager, accountId),
-            auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-              "accountId" -> accountId,
-              "reasonNotClosed" -> ErrorAccountCancellationPeriodExceeded.errorCode)
-          )
-          LisaMetrics.incrementMetrics(startTime,
-            LisaMetricKeys.lisaError(FORBIDDEN,LisaMetricKeys.CLOSE))
-
-          Forbidden(Json.toJson(ErrorAccountCancellationPeriodExceeded))
-        }
-        case CloseLisaAccountWithinCancellationPeriod => {
-          auditService.audit(
-            auditType = "accountNotClosed",
-            path = getCloseEndpointUrl(lisaManager, accountId),
-            auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-              "accountId" -> accountId,
-              "reasonNotClosed" -> ErrorAccountWithinCancellationPeriod.errorCode)
-          )
-          LisaMetrics.incrementMetrics(startTime,
-            LisaMetricKeys.lisaError(FORBIDDEN,LisaMetricKeys.CLOSE))
-
-          Forbidden(Json.toJson(ErrorAccountWithinCancellationPeriod))
-        }
-        case CloseLisaAccountNotFoundResponse => {
-          auditService.audit(
-            auditType = "accountNotClosed",
-            path = getCloseEndpointUrl(lisaManager, accountId),
-            auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-              "accountId" -> accountId,
-              "reasonNotClosed" -> ErrorAccountNotFound.errorCode)
-          )
-          LisaMetrics.incrementMetrics(startTime,
-            LisaMetricKeys.lisaError(NOT_FOUND,LisaMetricKeys.CLOSE))
-
-          NotFound(Json.toJson(ErrorAccountNotFound))
-        }
-        case _ => {
-          auditService.audit(
-            auditType = "accountNotClosed",
-            path = getCloseEndpointUrl(lisaManager, accountId),
-            auditData = closeLisaAccountRequest.toStringMap ++ Map(ZREF -> lisaManager,
-              "accountId" -> accountId,
-              "reasonNotClosed" -> ErrorInternalServerError.errorCode)
-          )
-          Logger.error(s"AccountController: closeAccount unknown case from DES returning internal server error" )
-          LisaMetrics.incrementMetrics(startTime,
-            LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR,LisaMetricKeys.CLOSE))
-
+            LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR, LisaMetricKeys.CLOSE))
           InternalServerError(Json.toJson(ErrorInternalServerError))
-        }
       }
-    } recover {
-        case e:Exception  =>     Logger.error(s"AccountController: closeAccount: An error occurred due to ${e.getMessage} returning internal server error")
-                              LisaMetrics.incrementMetrics(startTime,
-                                LisaMetricKeys.lisaError(INTERNAL_SERVER_ERROR,LisaMetricKeys.CLOSE))
-                              InternalServerError(Json.toJson(ErrorInternalServerError))
-       }
+    }
   }
 
   private def hasAccountTransferData(js: JsObject): Boolean = {

--- a/app/uk/gov/hmrc/lisaapi/controllers/LifeEventController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/LifeEventController.scala
@@ -43,6 +43,12 @@ class LifeEventController extends LisaController with LisaConstants {
       withValidLMRN(lisaManager) {
         withValidJson[ReportLifeEventRequest](req => {
             if (req.eventDate.isBefore(LISA_START_DATE)) {
+              Logger.debug("Life event not reported - invalid event date")
+
+              doAudit(lisaManager, accountId, req, "lifeEventNotReported", Map("reasonNotReported" -> "FORBIDDEN"))
+              LisaMetrics.incrementMetrics(startTime,
+                LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
+
               Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
                 ErrorValidation("INVALID_DATE", "The eventDate cannot be before 6 April 2017", Some("/eventDate"))
               )))))

--- a/app/uk/gov/hmrc/lisaapi/controllers/LifeEventController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/LifeEventController.scala
@@ -50,7 +50,7 @@ class LifeEventController extends LisaController with LisaConstants {
                 LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
 
               Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
-                ErrorValidation("INVALID_DATE", "The eventDate cannot be before 6 April 2017", Some("/eventDate"))
+                ErrorValidation(DATE_ERROR, LISA_START_DATE_ERROR.format("eventDate"), Some("/eventDate"))
               )))))
             }
             else {

--- a/app/uk/gov/hmrc/lisaapi/controllers/LifeEventController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/LifeEventController.scala
@@ -26,8 +26,11 @@ import uk.gov.hmrc.lisaapi.utils.LisaExtensions._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.lisaapi.LisaConstants
 
-class LifeEventController extends LisaController {
+import scala.concurrent.Future
+
+class LifeEventController extends LisaController with LisaConstants {
 
   val service: LifeEventService = LifeEventService
   val auditService: AuditService = AuditService
@@ -38,66 +41,74 @@ class LifeEventController extends LisaController {
       LisaMetrics.startMetrics(startTime, LisaMetricKeys.EVENT)
 
       withValidLMRN(lisaManager) {
-        withValidJson[ReportLifeEventRequest](req =>
-          service.reportLifeEvent(lisaManager, accountId, req) map { res =>
-            Logger.debug("Entering LifeEvent Controller and the response is " + res.toString)
-            res match {
-              case ReportLifeEventSuccessResponse(lifeEventId) => {
-                Logger.debug("Matched Valid Response ")
+        withValidJson[ReportLifeEventRequest](req => {
+            if (req.eventDate.isBefore(LISA_START_DATE)) {
+              Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
+                ErrorValidation("INVALID_DATE", "The eventDate cannot be before 6 April 2017", Some("/eventDate"))
+              )))))
+            }
+            else {
+              service.reportLifeEvent(lisaManager, accountId, req) map { res =>
+                Logger.debug("Entering LifeEvent Controller and the response is " + res.toString)
+                res match {
+                  case ReportLifeEventSuccessResponse(lifeEventId) => {
+                    Logger.debug("Matched Valid Response ")
 
-                doAudit(lisaManager, accountId, req, "lifeEventReported")
+                    doAudit(lisaManager, accountId, req, "lifeEventReported")
 
-                val data = ApiResponseData(message = "Life event created", lifeEventId = Some(lifeEventId))
+                    val data = ApiResponseData(message = "Life event created", lifeEventId = Some(lifeEventId))
 
-                LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.EVENT)
+                    LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.EVENT)
 
-                Created(Json.toJson(ApiResponse(data = Some(data), success = true, status = 201)))
-              }
-              case ReportLifeEventInappropriateResponse => {
-                Logger.debug("Matched Inappropriate")
+                    Created(Json.toJson(ApiResponse(data = Some(data), success = true, status = 201)))
+                  }
+                  case ReportLifeEventInappropriateResponse => {
+                    Logger.debug("Matched Inappropriate")
 
-                doAudit(lisaManager, accountId, req, "lifeEventNotReported", Map("reasonNotReported" -> ErrorLifeEventInappropriate.errorCode))
-                LisaMetrics.incrementMetrics(startTime,
-                  LisaMetricKeys.lisaError(FORBIDDEN,request.uri))
+                    doAudit(lisaManager, accountId, req, "lifeEventNotReported", Map("reasonNotReported" -> ErrorLifeEventInappropriate.errorCode))
+                    LisaMetrics.incrementMetrics(startTime,
+                      LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
 
-                Forbidden(Json.toJson(ErrorLifeEventInappropriate))
-              }
-              case ReportLifeEventAccountClosedResponse => {
-                Logger.error(("Account Closed or VOID"))
-                LisaMetrics.incrementMetrics(startTime,
-                  LisaMetricKeys.lisaError(FORBIDDEN,request.uri))
+                    Forbidden(Json.toJson(ErrorLifeEventInappropriate))
+                  }
+                  case ReportLifeEventAccountClosedResponse => {
+                    Logger.error(("Account Closed or VOID"))
+                    LisaMetrics.incrementMetrics(startTime,
+                      LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
 
-                Forbidden(Json.toJson(ErrorAccountAlreadyClosedOrVoid))
-              }
-              case ReportLifeEventAlreadyExistsResponse(lifeEventId)=> {
-                val result = ErrorLifeEventAlreadyExists (lifeEventId)
-                Logger.debug("Matched Already Exists")
+                    Forbidden(Json.toJson(ErrorAccountAlreadyClosedOrVoid))
+                  }
+                  case ReportLifeEventAlreadyExistsResponse(lifeEventId) => {
+                    val result = ErrorLifeEventAlreadyExists(lifeEventId)
+                    Logger.debug("Matched Already Exists")
 
-                doAudit(lisaManager, accountId, req, "lifeEventNotReported", Map("reasonNotReported" -> result.errorCode))
-                LisaMetrics.incrementMetrics(startTime,
-                  LisaMetricKeys.getErrorKey(CONFLICT,request.uri))
+                    doAudit(lisaManager, accountId, req, "lifeEventNotReported", Map("reasonNotReported" -> result.errorCode))
+                    LisaMetrics.incrementMetrics(startTime,
+                      LisaMetricKeys.getErrorKey(CONFLICT, request.uri))
 
-                Conflict(Json.toJson(result))
-              }
-              case ReportLifeEventAccountNotFoundResponse => {
-                Logger.debug("Matched Not Found")
+                    Conflict(Json.toJson(result))
+                  }
+                  case ReportLifeEventAccountNotFoundResponse => {
+                    Logger.debug("Matched Not Found")
 
-                doAudit(lisaManager, accountId, req, "lifeEventNotReported", Map("reasonNotReported" -> ErrorAccountNotFound.errorCode))
-                LisaMetrics.incrementMetrics(startTime,
-                  LisaMetricKeys.getErrorKey(NOT_FOUND,request.uri))
+                    doAudit(lisaManager, accountId, req, "lifeEventNotReported", Map("reasonNotReported" -> ErrorAccountNotFound.errorCode))
+                    LisaMetrics.incrementMetrics(startTime,
+                      LisaMetricKeys.getErrorKey(NOT_FOUND, request.uri))
 
-                NotFound(Json.toJson(ErrorAccountNotFound))
-              }
-              case _ => {
-                Logger.debug("Matched Error")
+                    NotFound(Json.toJson(ErrorAccountNotFound))
+                  }
+                  case _ => {
+                    Logger.debug("Matched Error")
 
-                doAudit(lisaManager, accountId, req, "lifeEventNotReported", Map("reasonNotReported" -> ErrorInternalServerError.errorCode))
+                    doAudit(lisaManager, accountId, req, "lifeEventNotReported", Map("reasonNotReported" -> ErrorInternalServerError.errorCode))
 
-                Logger.error(s"Life Event Not reported : DES unknown case , returning internal server error")
-                LisaMetrics.incrementMetrics(startTime,
-                  LisaMetricKeys.getErrorKey(INTERNAL_SERVER_ERROR,request.uri))
+                    Logger.error(s"Life Event Not reported : DES unknown case , returning internal server error")
+                    LisaMetrics.incrementMetrics(startTime,
+                      LisaMetricKeys.getErrorKey(INTERNAL_SERVER_ERROR, request.uri))
 
-                InternalServerError(Json.toJson(ErrorInternalServerError))
+                    InternalServerError(Json.toJson(ErrorInternalServerError))
+                  }
+                }
               }
             }
           }, lisaManager = lisaManager

--- a/app/uk/gov/hmrc/lisaapi/controllers/Responses.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/Responses.scala
@@ -20,10 +20,10 @@ import play.api.Logger
 import play.api.libs.json.Json
 
 sealed abstract class ErrorResponse(
-                                     val httpStatusCode: Int,
-                                     val errorCode: String,
-                                     val message: String
-                                   )
+                           val httpStatusCode: Int,
+                           val errorCode: String,
+                           val message: String
+                         )
 
 sealed abstract class ErrorResponseWithErrors(
                                      val httpStatusCode: Int,
@@ -46,12 +46,12 @@ case class ErrorResponseWithLifeEventId(
                                          lifeEventID: String
                                        )
 
-case class ErrorResponseWithAccountId(
-                                         httpStatusCode: Int,
-                                         errorCode: String,
-                                         message: String,
+case class ErrorResponseWithAccountId (
+                                         override val httpStatusCode: Int,
+                                         override val errorCode: String,
+                                         override val message: String,
                                          accountId: String
-                                       )
+                                       ) extends ErrorResponse(httpStatusCode, errorCode, message)
 
 
 case class ErrorValidation(

--- a/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.lisaapi.controllers
 
-import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, Result}
@@ -24,8 +23,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.lisaapi.LisaConstants
 import uk.gov.hmrc.lisaapi.metrics.{LisaMetricKeys, LisaMetrics}
 import uk.gov.hmrc.lisaapi.models.{UpdateSubscriptionSuccessResponse, _}
-import uk.gov.hmrc.lisaapi.services.AuditService
-import uk.gov.hmrc.lisaapi.services.UpdateSubscriptionService
+import uk.gov.hmrc.lisaapi.services.{AuditService, UpdateSubscriptionService}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -34,61 +32,75 @@ class UpdateSubscriptionController extends LisaController with LisaConstants {
   val service: UpdateSubscriptionService = UpdateSubscriptionService
   val auditService: AuditService = AuditService
 
+  val failureEvent: String = "firstSubscriptionDateNotUpdated"
+  val failureReason: String = "reasonNotUpdated"
+
   def updateSubscription (lisaManager: String, accountId: String): Action[AnyContent] = validateAccept(acceptHeaderValidationRules).async { implicit request =>
-    implicit val startTime = System.currentTimeMillis()
+    implicit val startTime: Long = System.currentTimeMillis()
     LisaMetrics.startMetrics(startTime, LisaMetricKeys.UPDATE_SUBSCRIPTION)
     withValidLMRN(lisaManager) {
       withValidAccountId(accountId) {
         withValidJson[UpdateSubscriptionRequest]( updateSubsRequest => {
-          if (updateSubsRequest.firstSubscriptionDate.isBefore(LISA_START_DATE)) {
-            Logger.debug("First Subscription date not updated - failed business rule validation")
-            doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> "FORBIDDEN"))
-            LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.getErrorKey(FORBIDDEN, request.uri))
-            Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
-              ErrorValidation(DATE_ERROR, LISA_START_DATE_ERROR.format("firstSubscriptionDate"), Some("/firstSubscriptionDate"))
-            )))))
-          }
-          else {
+          hasValidDates(lisaManager, accountId, updateSubsRequest, request.uri) { () =>
             service.updateSubscription(lisaManager, accountId, updateSubsRequest) map { result =>
               Logger.debug("Entering Updated subscription Controller and the response is " + result.toString)
               result match {
-                case success: UpdateSubscriptionSuccessResponse => {
+                case success: UpdateSubscriptionSuccessResponse =>
                   Logger.debug("First Subscription date updated")
                   doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateUpdated")
                   val data = ApiResponseData(message = success.message, code = Some(success.code), accountId = Some(accountId))
                   LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.UPDATE_SUBSCRIPTION)
-                  Ok(Json.toJson(ApiResponse(data = Some(data), success = true, status = 200)))
-                }
-                case UpdateSubscriptionAccountNotFoundResponse => {
+                  Ok(Json.toJson(ApiResponse(data = Some(data), success = true, status = OK)))
+                case UpdateSubscriptionAccountNotFoundResponse =>
                   Logger.debug("First Subscription date not updated")
-                  doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorAccountNotFound.errorCode))
+                  doAudit(lisaManager, accountId, updateSubsRequest, failureEvent,
+                    Map(failureReason -> ErrorAccountNotFound.errorCode))
                   LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.getErrorKey(NOT_FOUND, request.uri))
                   NotFound(Json.toJson(ErrorAccountNotFound))
-                }
-                case UpdateSubscriptionAccountClosedResponse => {
+                case UpdateSubscriptionAccountClosedResponse =>
                   Logger.error("Account Closed")
-                  doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorAccountAlreadyClosed.errorCode))
+                  doAudit(lisaManager, accountId, updateSubsRequest, failureEvent,
+                    Map(failureReason -> ErrorAccountAlreadyClosed.errorCode))
                   LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
                   Forbidden(Json.toJson(ErrorAccountAlreadyClosed))
-                }
-                case UpdateSubscriptionAccountVoidedResponse => {
+                case UpdateSubscriptionAccountVoidedResponse =>
                   Logger.error("Account Voided")
-                  doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorAccountAlreadyVoided.errorCode))
+                  doAudit(lisaManager, accountId, updateSubsRequest, failureEvent,
+                    Map(failureReason -> ErrorAccountAlreadyVoided.errorCode))
                   LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
                   Forbidden(Json.toJson(ErrorAccountAlreadyVoided))
-                }
-                case _ => {
+                case _ =>
                   Logger.debug("Matched Error")
-                  doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorInternalServerError.errorCode))
+                  doAudit(lisaManager, accountId, updateSubsRequest, failureEvent,
+                    Map(failureReason -> ErrorInternalServerError.errorCode))
                   Logger.error(s"First Subscription date not updated : DES unknown case , returning internal server error")
                   LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.getErrorKey(INTERNAL_SERVER_ERROR, request.uri))
                   InternalServerError(Json.toJson(ErrorInternalServerError))
-                }
               }
             }
           }
         }, lisaManager = lisaManager)
       }
+    }
+  }
+
+  private def hasValidDates(lisaManager: String, accountId: String, updateSubsRequest: UpdateSubscriptionRequest, uri: String)
+                                     (success: () => Future[Result])
+                                     (implicit hc: HeaderCarrier, startTime:Long): Future[Result] = {
+
+    if (updateSubsRequest.firstSubscriptionDate.isBefore(LISA_START_DATE)) {
+      Logger.debug("First Subscription date not updated - failed business rule validation")
+
+      doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> "FORBIDDEN"))
+
+      LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.getErrorKey(FORBIDDEN, uri))
+
+      Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
+        ErrorValidation(DATE_ERROR, LISA_START_DATE_ERROR.format("firstSubscriptionDate"), Some("/firstSubscriptionDate"))
+      )))))
+    }
+    else {
+      success()
     }
   }
 

--- a/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
@@ -41,7 +41,7 @@ class UpdateSubscriptionController extends LisaController with LisaConstants {
     withValidLMRN(lisaManager) {
       withValidAccountId(accountId) {
         withValidJson[UpdateSubscriptionRequest]( updateSubsRequest => {
-          hasValidDates(lisaManager, accountId, updateSubsRequest, request.uri) { () =>
+          withValidDates(lisaManager, accountId, updateSubsRequest, request.uri) { () =>
             service.updateSubscription(lisaManager, accountId, updateSubsRequest) map { result =>
               Logger.debug("Entering Updated subscription Controller and the response is " + result.toString)
               result match {
@@ -84,7 +84,7 @@ class UpdateSubscriptionController extends LisaController with LisaConstants {
     }
   }
 
-  private def hasValidDates(lisaManager: String, accountId: String, updateSubsRequest: UpdateSubscriptionRequest, uri: String)
+  private def withValidDates(lisaManager: String, accountId: String, updateSubsRequest: UpdateSubscriptionRequest, uri: String)
                                      (success: () => Future[Result])
                                      (implicit hc: HeaderCarrier, startTime:Long): Future[Result] = {
 

--- a/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
@@ -45,7 +45,7 @@ class UpdateSubscriptionController extends LisaController with LisaConstants {
             doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> "FORBIDDEN"))
             LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.getErrorKey(FORBIDDEN, request.uri))
             Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
-              ErrorValidation("INVALID_DATE", "The firstSubscriptionDate cannot be before 6 April 2017", Some("/firstSubscriptionDate"))
+              ErrorValidation(DATE_ERROR, LISA_START_DATE_ERROR.format("firstSubscriptionDate"), Some("/firstSubscriptionDate"))
             )))))
           }
           else {

--- a/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.lisaapi.controllers
 
+import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
@@ -27,6 +28,7 @@ import uk.gov.hmrc.lisaapi.services.AuditService
 import uk.gov.hmrc.lisaapi.services.UpdateSubscriptionService
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class UpdateSubscriptionController extends LisaController with LisaConstants {
   val service: UpdateSubscriptionService = UpdateSubscriptionService
@@ -39,62 +41,70 @@ class UpdateSubscriptionController extends LisaController with LisaConstants {
     LisaMetrics.startMetrics(startTime, LisaMetricKeys.UPDATE_SUBSCRIPTION)
     withValidLMRN(lisaManager) {
       withValidAccountId(accountId) {
-        withValidJson [UpdateSubscriptionRequest]( updateSubsRequest =>
-          service.updateSubscription(lisaManager, accountId, updateSubsRequest) map { result =>
-            Logger.debug("Entering Updated subscription Controller and the response is " + result.toString)
-            result match {
-              case success: UpdateSubscriptionSuccessResponse => {
-                Logger.debug("First Subscription date updated")
-                doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateUpdated")
+        withValidJson[UpdateSubscriptionRequest]( updateSubsRequest => {
+          if (updateSubsRequest.firstSubscriptionDate.isBefore(lisaStartDate)) {
+            Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
+              ErrorValidation("INVALID_DATE", "The firstSubscriptionDate must not be before the 6th of April 2017", Some("/firstSubscriptionDate"))
+            )))))
+          }
+          else {
+            service.updateSubscription(lisaManager, accountId, updateSubsRequest) map { result =>
+              Logger.debug("Entering Updated subscription Controller and the response is " + result.toString)
+              result match {
+                case success: UpdateSubscriptionSuccessResponse => {
+                  Logger.debug("First Subscription date updated")
+                  doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateUpdated")
 
-                val data = ApiResponseData(message = success.message, code = Some(success.code) ,accountId = Some(accountId))
-                LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.UPDATE_SUBSCRIPTION)
-                Ok(Json.toJson(ApiResponse(data = Some(data), success = true, status = 200)))
-              }
+                  val data = ApiResponseData(message = success.message, code = Some(success.code), accountId = Some(accountId))
+                  LisaMetrics.incrementMetrics(startTime, LisaMetricKeys.UPDATE_SUBSCRIPTION)
+                  Ok(Json.toJson(ApiResponse(data = Some(data), success = true, status = 200)))
+                }
 
-              case UpdateSubscriptionAccountNotFoundResponse => {
-                Logger.debug("First Subscription date not updated")
+                case UpdateSubscriptionAccountNotFoundResponse => {
+                  Logger.debug("First Subscription date not updated")
 
-                doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorAccountNotFound.errorCode))
-                LisaMetrics.incrementMetrics(startTime,
-                  LisaMetricKeys.getErrorKey(NOT_FOUND, request.uri))
+                  doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorAccountNotFound.errorCode))
+                  LisaMetrics.incrementMetrics(startTime,
+                    LisaMetricKeys.getErrorKey(NOT_FOUND, request.uri))
 
-                NotFound(Json.toJson(ErrorAccountNotFound))
-              }
-              case UpdateSubscriptionAccountClosedResponse => {
-                Logger.error(("Account Closed"))
-                doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorAccountAlreadyClosed.errorCode))
-                LisaMetrics.incrementMetrics(startTime,
-                  LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
+                  NotFound(Json.toJson(ErrorAccountNotFound))
+                }
+                case UpdateSubscriptionAccountClosedResponse => {
+                  Logger.error(("Account Closed"))
+                  doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorAccountAlreadyClosed.errorCode))
+                  LisaMetrics.incrementMetrics(startTime,
+                    LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
 
-                Forbidden(Json.toJson(ErrorAccountAlreadyClosed))
-              }
-              case UpdateSubscriptionAccountVoidedResponse => {
-                Logger.error(("Account Voided"))
-                doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorAccountAlreadyVoided.errorCode))
-                LisaMetrics.incrementMetrics(startTime,
-                  LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
+                  Forbidden(Json.toJson(ErrorAccountAlreadyClosed))
+                }
+                case UpdateSubscriptionAccountVoidedResponse => {
+                  Logger.error(("Account Voided"))
+                  doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorAccountAlreadyVoided.errorCode))
+                  LisaMetrics.incrementMetrics(startTime,
+                    LisaMetricKeys.lisaError(FORBIDDEN, request.uri))
 
-                Forbidden(Json.toJson(ErrorAccountAlreadyVoided))
-              }
-              case _ => {
-                Logger.debug("Matched Error")
+                  Forbidden(Json.toJson(ErrorAccountAlreadyVoided))
+                }
+                case _ => {
+                  Logger.debug("Matched Error")
 
-                doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorInternalServerError.errorCode))
+                  doAudit(lisaManager, accountId, updateSubsRequest, "firstSubscriptionDateNotUpdated", Map("reasonNotUpdated" -> ErrorInternalServerError.errorCode))
 
-                Logger.error(s"First Subscription date not updated : DES unknown case , returning internal server error")
-                LisaMetrics.incrementMetrics(startTime,
-                  LisaMetricKeys.getErrorKey(INTERNAL_SERVER_ERROR, request.uri))
+                  Logger.error(s"First Subscription date not updated : DES unknown case , returning internal server error")
+                  LisaMetrics.incrementMetrics(startTime,
+                    LisaMetricKeys.getErrorKey(INTERNAL_SERVER_ERROR, request.uri))
 
-                InternalServerError(Json.toJson(ErrorInternalServerError))
+                  InternalServerError(Json.toJson(ErrorInternalServerError))
+                }
               }
             }
-          }, lisaManager = lisaManager
-        )
+          }
+        }, lisaManager = lisaManager)
       }
     }
   }
 
+  private val lisaStartDate = new DateTime(2017, 4, 6, 0, 0)
 
   private def doAudit(lisaManager: String, accountId: String, updateSubsRequest: UpdateSubscriptionRequest, auditType: String, extraData: Map[String, String] = Map())(implicit hc: HeaderCarrier) = {
     auditService.audit(

--- a/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/UpdateSubscriptionController.scala
@@ -87,7 +87,7 @@ class UpdateSubscriptionController extends LisaController with LisaConstants {
   private def withValidDate(req: UpdateSubscriptionRequest)(success: (UpdateSubscriptionRequest) => Future[Result]) = {
     if (req.firstSubscriptionDate.isBefore(LISA_START_DATE)) {
       Future.successful(Forbidden(Json.toJson(ErrorForbidden(List(
-        ErrorValidation("INVALID_DATE", "The firstSubscriptionDate must not be before the 6th of April 2017", Some("/firstSubscriptionDate"))
+        ErrorValidation("INVALID_DATE", "The firstSubscriptionDate cannot be before the 6th of April 2017", Some("/firstSubscriptionDate"))
       )))))
     }
     else {

--- a/app/uk/gov/hmrc/lisaapi/controllers/package.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/package.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.lisaapi
 
+import org.joda.time.DateTime
 import play.api.libs.json.{JsPath, JsValue, Json, Writes}
 
 package object controllers {
@@ -51,4 +52,5 @@ package object controllers {
 trait LisaConstants {
   val ZREF: String = "lisaManagerReferenceNumber"
   val NOTIFICATION:String  = "lateNotification"
+  val LISA_START_DATE = new DateTime(2017, 4, 6, 0, 0)
 }

--- a/app/uk/gov/hmrc/lisaapi/controllers/package.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/package.scala
@@ -53,6 +53,7 @@ trait LisaConstants {
   val ZREF: String = "lisaManagerReferenceNumber"
   val NOTIFICATION:String  = "lateNotification"
   val DATE_ERROR = "INVALID_DATE"
+  val MONETARY_ERROR = "INVALID_MONETARY_AMOUNT"
   val LISA_START_DATE = new DateTime(2017, 4, 6, 0, 0)
   val LISA_START_DATE_ERROR = "The %s cannot be before 6 April 2017"
 }

--- a/app/uk/gov/hmrc/lisaapi/controllers/package.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/package.scala
@@ -54,6 +54,6 @@ trait LisaConstants {
   val NOTIFICATION:String  = "lateNotification"
   val DATE_ERROR = "INVALID_DATE"
   val MONETARY_ERROR = "INVALID_MONETARY_AMOUNT"
-  val LISA_START_DATE = new DateTime(2017, 4, 6, 0, 0)
+  val LISA_START_DATE = new DateTime("2017-04-06")
   val LISA_START_DATE_ERROR = "The %s cannot be before 6 April 2017"
 }

--- a/app/uk/gov/hmrc/lisaapi/controllers/package.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/package.scala
@@ -52,5 +52,7 @@ package object controllers {
 trait LisaConstants {
   val ZREF: String = "lisaManagerReferenceNumber"
   val NOTIFICATION:String  = "lateNotification"
+  val DATE_ERROR = "INVALID_DATE"
   val LISA_START_DATE = new DateTime(2017, 4, 6, 0, 0)
+  val LISA_START_DATE_ERROR = "The %s cannot be before 6 April 2017"
 }

--- a/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
+++ b/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.lisaapi.utils
 
-import org.joda.time.DateTime
 import uk.gov.hmrc.lisaapi.LisaConstants
 import uk.gov.hmrc.lisaapi.controllers.ErrorValidation
 import uk.gov.hmrc.lisaapi.models.RequestBonusPaymentRequest
@@ -32,7 +31,6 @@ trait BonusPaymentValidator extends LisaConstants {
   val htbTransfer: String = "/htbTransfer"
   val bonuses: String = "/bonuses"
   val currentDateService: CurrentDateService
-  val firstValidDate: DateTime = new DateTime(2017, 4, 6, 0, 0)
 
   def validate(data: RequestBonusPaymentRequest): Seq[ErrorValidation] = {
     (
@@ -152,7 +150,7 @@ trait BonusPaymentValidator extends LisaConstants {
   private val periodStartDateIsNotBeforeFirstValidDate: (BonusPaymentValidationRequest) => BonusPaymentValidationRequest =
     (req: BonusPaymentValidationRequest) => {
 
-    if (req.data.periodStartDate.isBefore(firstValidDate)) {
+    if (req.data.periodStartDate.isBefore(LISA_START_DATE)) {
       req.copy(errors = req.errors :+ ErrorValidation(
         errorCode = DATE_ERROR,
         message = LISA_START_DATE_ERROR.format("periodStartDate"),
@@ -167,7 +165,7 @@ trait BonusPaymentValidator extends LisaConstants {
   private val periodEndDateIsNotBeforeFirstValidDate: (BonusPaymentValidationRequest) => BonusPaymentValidationRequest =
     (req: BonusPaymentValidationRequest) => {
 
-    if (req.data.periodEndDate.isBefore(firstValidDate)) {
+    if (req.data.periodEndDate.isBefore(LISA_START_DATE)) {
       req.copy(errors = req.errors :+ ErrorValidation(
         errorCode = DATE_ERROR,
         message = LISA_START_DATE_ERROR.format("periodEndDate"),

--- a/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
+++ b/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.lisaapi.utils
 
 import org.joda.time.DateTime
+import uk.gov.hmrc.lisaapi.LisaConstants
 import uk.gov.hmrc.lisaapi.controllers.ErrorValidation
 import uk.gov.hmrc.lisaapi.models.RequestBonusPaymentRequest
 import uk.gov.hmrc.lisaapi.services.CurrentDateService
@@ -25,7 +26,7 @@ import scala.collection.mutable.ListBuffer
 
 case class BonusPaymentValidationRequest(data: RequestBonusPaymentRequest, errors: Seq[ErrorValidation] = Nil)
 
-trait BonusPaymentValidator {
+trait BonusPaymentValidator extends LisaConstants {
 
   val inboundPayments: String = "/inboundPayments"
   val htbTransfer: String = "/htbTransfer"
@@ -156,7 +157,7 @@ trait BonusPaymentValidator {
     if (req.data.periodStartDate.isBefore(firstValidDate)) {
       req.copy(errors = req.errors :+ ErrorValidation(
         errorCode = dateErrorCode,
-        message = "The periodStartDate cannot be before 6 April 2017",
+        message = LISA_START_DATE_ERROR.format("periodStartDate"),
         path = Some(s"/periodStartDate")
       ))
     }
@@ -171,7 +172,7 @@ trait BonusPaymentValidator {
     if (req.data.periodEndDate.isBefore(firstValidDate)) {
       req.copy(errors = req.errors :+ ErrorValidation(
         errorCode = dateErrorCode,
-        message = "The periodEndDate cannot be before 6 April 2017",
+        message = LISA_START_DATE_ERROR.format("periodEndDate"),
         path = Some(s"/periodEndDate")
       ))
     }

--- a/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
+++ b/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
@@ -31,8 +31,6 @@ trait BonusPaymentValidator extends LisaConstants {
   val inboundPayments: String = "/inboundPayments"
   val htbTransfer: String = "/htbTransfer"
   val bonuses: String = "/bonuses"
-  val monetaryErrorCode: String = "INVALID_MONETARY_AMOUNT"
-  val dateErrorCode: String = "INVALID_DATE"
   val currentDateService: CurrentDateService
   val firstValidDate: DateTime = new DateTime(2017, 4, 6, 0, 0)
 
@@ -72,7 +70,7 @@ trait BonusPaymentValidator extends LisaConstants {
       req.data.inboundPayments.newSubsForPeriod.get > 0 &&
       req.data.inboundPayments.newSubsYTD <= 0) => {
 
-      req.copy(errors = req.errors :+ ErrorValidation(monetaryErrorCode, "newSubsYTD must be more than 0", Some(s"$inboundPayments/newSubsYTD")))
+      req.copy(errors = req.errors :+ ErrorValidation(MONETARY_ERROR, "newSubsYTD must be more than 0", Some(s"$inboundPayments/newSubsYTD")))
     }
     case req: BonusPaymentValidationRequest => req
   }
@@ -83,14 +81,14 @@ trait BonusPaymentValidator extends LisaConstants {
       req.data.htbTransfer.get.htbTransferInForPeriod > 0 &&
       req.data.htbTransfer.get.htbTransferTotalYTD <= 0) => {
 
-      req.copy(errors = req.errors :+ ErrorValidation(monetaryErrorCode, "htbTransferTotalYTD must be more than 0", Some(s"$htbTransfer/htbTransferTotalYTD")))
+      req.copy(errors = req.errors :+ ErrorValidation(MONETARY_ERROR, "htbTransferTotalYTD must be more than 0", Some(s"$htbTransfer/htbTransferTotalYTD")))
     }
     case req: BonusPaymentValidationRequest => req
   }
 
   private val totalSubsForPeriodGtZero: PartialFunction[BonusPaymentValidationRequest, BonusPaymentValidationRequest] = {
     case req: BonusPaymentValidationRequest if (req.data.inboundPayments.totalSubsForPeriod <= 0) => {
-      req.copy(errors = req.errors :+ ErrorValidation(monetaryErrorCode, "totalSubsForPeriod must be more than 0", Some(s"$inboundPayments/totalSubsForPeriod")))
+      req.copy(errors = req.errors :+ ErrorValidation(MONETARY_ERROR, "totalSubsForPeriod must be more than 0", Some(s"$inboundPayments/totalSubsForPeriod")))
     }
     case req: BonusPaymentValidationRequest => req
   }
@@ -98,7 +96,7 @@ trait BonusPaymentValidator extends LisaConstants {
   private val totalSubsYTDGteTotalSubsForPeriod: PartialFunction[BonusPaymentValidationRequest, BonusPaymentValidationRequest] = {
     case req: BonusPaymentValidationRequest if (req.data.inboundPayments.totalSubsYTD < req.data.inboundPayments.totalSubsForPeriod) => {
       req.copy(errors = req.errors :+
-        ErrorValidation(monetaryErrorCode, "totalSubsYTD must be more than or equal to totalSubsForPeriod", Some(s"$inboundPayments/totalSubsYTD"))
+        ErrorValidation(MONETARY_ERROR, "totalSubsYTD must be more than or equal to totalSubsForPeriod", Some(s"$inboundPayments/totalSubsYTD"))
       )
     }
     case req: BonusPaymentValidationRequest => req
@@ -106,28 +104,28 @@ trait BonusPaymentValidator extends LisaConstants {
 
   private val bonusDueForPeriodGtZero: PartialFunction[BonusPaymentValidationRequest, BonusPaymentValidationRequest] = {
     case req: BonusPaymentValidationRequest if (req.data.bonuses.bonusDueForPeriod <= 0) => {
-      req.copy(errors = req.errors :+ ErrorValidation(monetaryErrorCode, "bonusDueForPeriod must be more than 0", Some(s"$bonuses/bonusDueForPeriod")))
+      req.copy(errors = req.errors :+ ErrorValidation(MONETARY_ERROR, "bonusDueForPeriod must be more than 0", Some(s"$bonuses/bonusDueForPeriod")))
     }
     case req: BonusPaymentValidationRequest => req
   }
 
   private val totalBonusDueYTDGtZero: PartialFunction[BonusPaymentValidationRequest, BonusPaymentValidationRequest] = {
     case req: BonusPaymentValidationRequest if (req.data.bonuses.totalBonusDueYTD <= 0) => {
-      req.copy(errors = req.errors :+ ErrorValidation(monetaryErrorCode, "totalBonusDueYTD must be more than 0", Some(s"$bonuses/totalBonusDueYTD")))
+      req.copy(errors = req.errors :+ ErrorValidation(MONETARY_ERROR, "totalBonusDueYTD must be more than 0", Some(s"$bonuses/totalBonusDueYTD")))
     }
     case req: BonusPaymentValidationRequest => req
   }
 
   private val periodStartDateIsSixth: PartialFunction[BonusPaymentValidationRequest, BonusPaymentValidationRequest] = {
     case req: BonusPaymentValidationRequest if req.data.periodStartDate.getDayOfMonth() != 6 => {
-      req.copy(errors = req.errors :+ ErrorValidation(dateErrorCode, "The periodStartDate must be the 6th day of the month", Some(s"/periodStartDate")))
+      req.copy(errors = req.errors :+ ErrorValidation(DATE_ERROR, "The periodStartDate must be the 6th day of the month", Some(s"/periodStartDate")))
     }
     case req: BonusPaymentValidationRequest => req
   }
 
   private val periodStartDateIsNotInFuture: PartialFunction[BonusPaymentValidationRequest, BonusPaymentValidationRequest] = {
     case req: BonusPaymentValidationRequest if req.data.periodStartDate.toDate.after(currentDateService.now().toDate) => {
-      req.copy(errors = req.errors :+ ErrorValidation(dateErrorCode, "The periodStartDate may not be a future date", Some(s"/periodStartDate")))
+      req.copy(errors = req.errors :+ ErrorValidation(DATE_ERROR, "The periodStartDate may not be a future date", Some(s"/periodStartDate")))
     }
     case req: BonusPaymentValidationRequest => req
   }
@@ -144,7 +142,7 @@ trait BonusPaymentValidator extends LisaConstants {
     }
     else {
       req.copy(errors = req.errors :+ ErrorValidation(
-        errorCode = dateErrorCode,
+        errorCode = DATE_ERROR,
         message = "The periodEndDate must be the 5th day of the month which occurs after the periodStartDate",
         path = Some(s"/periodEndDate")
       ))
@@ -156,7 +154,7 @@ trait BonusPaymentValidator extends LisaConstants {
 
     if (req.data.periodStartDate.isBefore(firstValidDate)) {
       req.copy(errors = req.errors :+ ErrorValidation(
-        errorCode = dateErrorCode,
+        errorCode = DATE_ERROR,
         message = LISA_START_DATE_ERROR.format("periodStartDate"),
         path = Some(s"/periodStartDate")
       ))
@@ -171,7 +169,7 @@ trait BonusPaymentValidator extends LisaConstants {
 
     if (req.data.periodEndDate.isBefore(firstValidDate)) {
       req.copy(errors = req.errors :+ ErrorValidation(
-        errorCode = dateErrorCode,
+        errorCode = DATE_ERROR,
         message = LISA_START_DATE_ERROR.format("periodEndDate"),
         path = Some(s"/periodEndDate")
       ))
@@ -189,8 +187,8 @@ trait BonusPaymentValidator extends LisaConstants {
 
     val errorMessage = "newSubsForPeriod and htbTransferInForPeriod cannot both be 0"
 
-    if (showSubError) newErrs += ErrorValidation(monetaryErrorCode, errorMessage, Some(s"$inboundPayments/newSubsForPeriod"))
-    if (showHtbError) newErrs += ErrorValidation(monetaryErrorCode, errorMessage, Some(s"$htbTransfer/htbTransferInForPeriod"))
+    if (showSubError) newErrs += ErrorValidation(MONETARY_ERROR, errorMessage, Some(s"$inboundPayments/newSubsForPeriod"))
+    if (showHtbError) newErrs += ErrorValidation(MONETARY_ERROR, errorMessage, Some(s"$htbTransfer/htbTransferInForPeriod"))
 
     newErrs
   }

--- a/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
+++ b/app/uk/gov/hmrc/lisaapi/utils/BonusPaymentValidator.scala
@@ -33,6 +33,7 @@ trait BonusPaymentValidator {
   val monetaryErrorCode: String = "INVALID_MONETARY_AMOUNT"
   val dateErrorCode: String = "INVALID_DATE"
   val currentDateService: CurrentDateService
+  val firstValidDate: DateTime = new DateTime(2017, 4, 6, 0, 0)
 
   def validate(data: RequestBonusPaymentRequest): Seq[ErrorValidation] = {
     (
@@ -45,7 +46,9 @@ trait BonusPaymentValidator {
       totalBonusDueYTDGtZero andThen
       periodStartDateIsSixth andThen
       periodEndDateIsFifthOfMonthAfterPeriodStartDate andThen
-      periodStartDateIsNotInFuture
+      periodStartDateIsNotInFuture andThen
+      periodStartDateIsNotBeforeFirstValidDate andThen
+      periodEndDateIsNotBeforeFirstValidDate
     ).apply(BonusPaymentValidationRequest(data)).errors
   }
 
@@ -144,6 +147,36 @@ trait BonusPaymentValidator {
         message = "The periodEndDate must be the 5th day of the month which occurs after the periodStartDate",
         path = Some(s"/periodEndDate")
       ))
+    }
+  }
+
+  private val periodStartDateIsNotBeforeFirstValidDate: (BonusPaymentValidationRequest) => BonusPaymentValidationRequest =
+    (req: BonusPaymentValidationRequest) => {
+
+    if (req.data.periodStartDate.isBefore(firstValidDate)) {
+      req.copy(errors = req.errors :+ ErrorValidation(
+        errorCode = dateErrorCode,
+        message = "The periodStartDate cannot be before 6 April 2017",
+        path = Some(s"/periodStartDate")
+      ))
+    }
+    else {
+      req
+    }
+  }
+
+  private val periodEndDateIsNotBeforeFirstValidDate: (BonusPaymentValidationRequest) => BonusPaymentValidationRequest =
+    (req: BonusPaymentValidationRequest) => {
+
+    if (req.data.periodEndDate.isBefore(firstValidDate)) {
+      req.copy(errors = req.errors :+ ErrorValidation(
+        errorCode = dateErrorCode,
+        message = "The periodEndDate cannot be before 6 April 2017",
+        path = Some(s"/periodEndDate")
+      ))
+    }
+    else {
+      req
     }
   }
 

--- a/resources/public/api/conf/1.0/examples/LISAAccount.post.json
+++ b/resources/public/api/conf/1.0/examples/LISAAccount.post.json
@@ -2,10 +2,10 @@
   "investorId" : "9876543210",
   "accountId" :"8765432100",
   "creationReason" : "Transferred",
-  "firstSubscriptionDate" : "2011-03-23",
+  "firstSubscriptionDate" : "2017-04-06",
   "transferAccount": {
     "transferredFromAccountId": "98123459898",
     "transferredFromLMRN": "Z543333",
-    "transferInDate": "2015-12-13"
+    "transferInDate": "2017-04-06"
   }
 }

--- a/resources/public/api/conf/1.0/examples/LISAAccount.post1.json
+++ b/resources/public/api/conf/1.0/examples/LISAAccount.post1.json
@@ -2,5 +2,5 @@
   "investorId": "9876543210",
   "creationReason": "New",
   "accountId": "1234567890",
-  "firstSubscriptionDate": "2011-03-23"
+  "firstSubscriptionDate": "2017-04-06"
 }

--- a/resources/public/api/conf/1.0/testdata/bonus-payment.md
+++ b/resources/public/api/conf/1.0/testdata/bonus-payment.md
@@ -202,75 +202,80 @@
             </td>
             <td>
                 <p class ="code--block"> {<br>
-                                             "lifeEventId": "1234567891",<br>
-                                             "periodStartDate": "9999-04-05",<br>
-                                             "periodEndDate": "9999-06-05",<br>
-                                             "htbTransfer": {<br>
-                                                 "htbTransferInForPeriod": 0.00,<br>
-                                                 "htbTransferTotalYTD": 0.00<br>
-                                             },<br>
-                                             "inboundPayments": {<br>
-                                                 "newSubsForPeriod": 0.00,<br>
-                                                 "newSubsYTD": 0.00,<br>
-                                                 "totalSubsForPeriod": 0.0,<br>
-                                                 "totalSubsYTD": 0.00<br>
-                                             },<br>
-                                             "bonuses": {<br>
-                                                 "bonusPaidYTD": 0.0,<br>
-                                                 "bonusDueForPeriod": 0.0,<br>
-                                                 "totalBonusDueYTD": 0.0,<br>
-                                                 "claimReason": "Life Event"<br>
-                                             }<br>
-                                         }
+                     "lifeEventId": "1234567891",<br>
+                     "periodStartDate": "9999-04-05",<br>
+                     "periodEndDate": "2016-06-05",<br>
+                     "htbTransfer": {<br>
+                         "htbTransferInForPeriod": 0.00,<br>
+                         "htbTransferTotalYTD": 0.00<br>
+                     },<br>
+                     "inboundPayments": {<br>
+                         "newSubsForPeriod": 0.00,<br>
+                         "newSubsYTD": 0.00,<br>
+                         "totalSubsForPeriod": 0.0,<br>
+                         "totalSubsYTD": 0.00<br>
+                     },<br>
+                     "bonuses": {<br>
+                         "bonusPaidYTD": 0.0,<br>
+                         "bonusDueForPeriod": 0.0,<br>
+                         "totalBonusDueYTD": 0.0,<br>
+                         "claimReason": "Life Event"<br>
+                     }<br>
+                 } 
                 </p>
             </td>
             <td><p>HTTP status: <code class="code--slim">403 (Forbidden)</code></p>
                 <p class ="code--block"> {<br>
-                                              "code": "FORBIDDEN",<br>
-                                              "message": "There is a problem with the request data",<br>
-                                              "errors": [<br>
-                                                  {<br>
-                                                      "code": "INVALID_MONETARY_AMOUNT",<br>
-                                                      "message": "newSubsForPeriod and htbTransferInForPeriod cannot both be 0",<br>
-                                                      "path": "/inboundPayments/newSubsForPeriod"<br>
-                                                  },<br>
-                                                  {<br>
-                                                      "code": "INVALID_MONETARY_AMOUNT",<br>
-                                                      "message": "newSubsForPeriod and htbTransferInForPeriod cannot both be 0",<br>
-                                                      "path": "/htbTransfer/htbTransferInForPeriod"<br>
-                                                  },<br>
-                                                  {<br>
-                                                      "code": "INVALID_MONETARY_AMOUNT",<br>
-                                                      "message": "totalSubsForPeriod must be more than 0",<br>
-                                                      "path": "/inboundPayments/totalSubsForPeriod"<br>
-                                                  },<br>
-                                                  {<br>
-                                                      "code": "INVALID_MONETARY_AMOUNT",<br>
-                                                      "message": "bonusDueForPeriod must be more than 0",<br>
-                                                      "path": "/bonuses/bonusDueForPeriod"<br>
-                                                  },<br>
-                                                  {<br>
-                                                      "code": "INVALID_MONETARY_AMOUNT",<br>
-                                                      "message": "totalBonusDueYTD must be more than 0",<br>
-                                                      "path": "/bonuses/totalBonusDueYTD"<br>
-                                                  },<br>
-                                                  {<br>
-                                                      "code": "INVALID_DATE",<br>
-                                                      "message": "The periodStartDate must be the 6th day of the month",<br>
-                                                      "path": "/periodStartDate"<br>
-                                                  },<br>
-                                                  {<br>
-                                                      "code": "INVALID_DATE",<br>
-                                                      "message": "The periodEndDate must be the 5th day of the month which occurs after the periodStartDate",<br>
-                                                      "path": "/periodEndDate"<br>
-                                                  },<br>
-                                                  {<br>
-                                                      "code": "INVALID_DATE",<br>
-                                                      "message": "The periodStartDate may not be a future date",<br>
-                                                      "path": "/periodStartDate"<br>
-                                                  }<br>
-                                              ]<br>
-                                          }
+                      "code": "FORBIDDEN",<br>
+                      "message": "There is a problem with the request data",<br>
+                      "errors": [<br>
+                          {<br>
+                              "code": "INVALID_MONETARY_AMOUNT",<br>
+                              "message": "newSubsForPeriod and htbTransferInForPeriod cannot both be 0",<br>
+                              "path": "/inboundPayments/newSubsForPeriod"<br>
+                          },<br>
+                          {<br>
+                              "code": "INVALID_MONETARY_AMOUNT",<br>
+                              "message": "newSubsForPeriod and htbTransferInForPeriod cannot both be 0",<br>
+                              "path": "/htbTransfer/htbTransferInForPeriod"<br>
+                          },<br>
+                          {<br>
+                              "code": "INVALID_MONETARY_AMOUNT",<br>
+                              "message": "totalSubsForPeriod must be more than 0",<br>
+                              "path": "/inboundPayments/totalSubsForPeriod"<br>
+                          },<br>
+                          {<br>
+                              "code": "INVALID_MONETARY_AMOUNT",<br>
+                              "message": "bonusDueForPeriod must be more than 0",<br>
+                              "path": "/bonuses/bonusDueForPeriod"<br>
+                          },<br>
+                          {<br>
+                              "code": "INVALID_MONETARY_AMOUNT",<br>
+                              "message": "totalBonusDueYTD must be more than 0",<br>
+                              "path": "/bonuses/totalBonusDueYTD"<br>
+                          },<br>
+                          {<br>
+                              "code": "INVALID_DATE",<br>
+                              "message": "The periodStartDate must be the 6th day of the month",<br>
+                              "path": "/periodStartDate"<br>
+                          },<br>
+                          {<br>
+                              "code": "INVALID_DATE",<br>
+                              "message": "The periodEndDate must be the 5th day of the month which occurs after the periodStartDate",<br>
+                              "path": "/periodEndDate"<br>
+                          },<br>
+                          {<br>
+                              "code": "INVALID_DATE",<br>
+                              "message": "The periodStartDate may not be a future date",<br>
+                              "path": "/periodStartDate"<br>
+                          },<br>
+                          {<br>
+                              "code": "INVALID_DATE",<br>
+                              "message": "The periodEndDate cannot be before 6 April 2017",<br>
+                              "path": "/periodEndDate"<br>
+                          }<br>
+                      ]<br>
+                  }
                 </p>
             </td>
         </tr>

--- a/resources/public/api/conf/1.0/testdata/close-account.md
+++ b/resources/public/api/conf/1.0/testdata/close-account.md
@@ -15,7 +15,7 @@
             <td>
                 <p class ="code--block"> {<br>
                                      	  "accountClosureReason":"All funds withdrawn",<br>
-                                     	  "closureDate": "2017-01-20"<br>
+                                     	  "closureDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -36,7 +36,7 @@
             <td>
                 <p class ="code--block"> {<br>
                                           "accountClosureReason":"Cancellation",<br>
-                                          "closureDate": "2017-01-20"<br>
+                                          "closureDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -57,7 +57,7 @@
             <td>
                 <p class ="code--block"> {<br>
                                      	  "accountClosureReason":"All funds withdrawn",<br>
-                                     	  "closureDate": "2017-01-20"<br>
+                                     	  "closureDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -73,27 +73,51 @@
             <td><p>Request containing invalid and/or missing data</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
                 <p class ="code--block"> {<br>
-                                     	  "closureDate": "3000-01-01"<br>
+                                     	  "closureDate": "3000"<br>
                                         }
                 </p>
             </td>
             <td><p>HTTP status: <code class="code--slim">400 (Bad Request)</code></p>
                 <p class ="code--block"> {<br>
-  "code": "BAD_REQUEST",<br>
-  "message": "Bad Request",<br>
-  "errors": [<br>
-    {<br>
-      "code": "INVALID_DATE",<br>
-      "message": "Date is invalid",<br>
-      "path": "/closureDate"<br>
-    },<br>
-    {<br>
-      "code": "MISSING_FIELD",<br>
-      "message": "This field is required",<br>
-      "path": "/accountClosureReason"<br>
-    }<br>
-  ]<br>
-}
+                      "code": "BAD_REQUEST",<br>
+                      "message": "Bad Request",<br>
+                      "errors": [<br>
+                        {<br>
+                          "code": "INVALID_DATE",<br>
+                          "message": "Date is invalid",<br>
+                          "path": "/closureDate"<br>
+                        },<br>
+                        {<br>
+                          "code": "MISSING_FIELD",<br>
+                          "message": "This field is required",<br>
+                          "path": "/accountClosureReason"<br>
+                        }<br>
+                      ]<br>
+                    }
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td><p>Request containing a closure date before 6 April 2017</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td>
+                <p class ="code--block"> {<br>
+                      "accountClosureReason": "All funds withdrawn",
+                      "closureDate": "2017-04-05"<br>
+                    }
+                </p>
+            </td>
+            <td><p>HTTP status: <code class="code--slim">403 (Forbidden)</code></p>
+                <p class ="code--block"> {<br>
+                      "code": "FORBIDDEN",<br>
+                      "message": "There is a problem with the request data",<br>
+                      "errors": [<br>
+                        {<br>
+                          "code": "INVALID_DATE",<br>
+                          "message": "The closureDate cannot be before 6 April 2017",<br>
+                          "path": "/closureDate"<br>
+                        }<br>
+                      ]<br>
+                    }
                 </p>
             </td>
         </tr>
@@ -102,7 +126,7 @@
             <td>
                 <p class ="code--block"> {<br>
                                      	  "accountClosureReason": "All funds withdrawn",<br>
-                                     	  "closureDate": "2017-01-20"<br>
+                                     	  "closureDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -119,7 +143,7 @@
             <td>
                 <p class ="code--block"> {<br>
                                      	  "accountClosureReason": "All funds withdrawn",<br>
-                                     	  "closureDate": "2017-01-20"<br>
+                                     	  "closureDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -136,7 +160,7 @@
             <td>
                 <p class ="code--block"> {<br>
                                           "accountClosureReason": "Cancellation",<br>
-                                          "closureDate": "2017-01-20"<br>
+                                          "closureDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -154,7 +178,7 @@
             <td>
                 <p class ="code--block"> {<br>
                                           "accountClosureReason": "All funds withdrawn",<br>
-                                          "closureDate": "2017-01-20"<br>
+                                          "closureDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -171,7 +195,7 @@
             <td>
                 <p class ="code--block"> {<br>
                                      	  "accountClosureReason": "All funds withdrawn",<br>
-                                     	  "closureDate": "2017-01-20"<br>
+                                     	  "closureDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -188,7 +212,7 @@
             <td>
                 <p class ="code--block"> {<br>
                                           "accountClosureReason": "All funds withdrawn",<br>
-                                          "closureDate": "2017-01-20"<br>
+                                          "closureDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>

--- a/resources/public/api/conf/1.0/testdata/create-account.md
+++ b/resources/public/api/conf/1.0/testdata/create-account.md
@@ -17,7 +17,7 @@
                                      	    "investorId": "9876543210",<br>
                                      	    "creationReason": "New",<br>
                                      	    "accountId": "1234567890",<br>
-                                     	    "firstSubscriptionDate": "2011-03-23"<br>
+                                     	    "firstSubscriptionDate": "2017-04-06"<br>
                                         }
                 </p>
             </td>
@@ -40,11 +40,11 @@
                                               "investorId": "9876543210",<br>
                                               "creationReason": "Transferred",<br>
                                               "accountId": "1234567890",<br>
-                                              "firstSubscriptionDate": "2011-03-23",<br>
+                                              "firstSubscriptionDate": "2017-04-06",<br>
                                               "transferAccount": {<br>
                                                 "transferredFromAccountId": "8765432100",<br>
                                                 "transferredFromLMRN": "Z654321",<br>
-                                                "transferInDate": "2015-12-13"<br>
+                                                "transferInDate": "2017-04-06"<br>
                                               }<br>
                                         }
                 </p>
@@ -68,7 +68,7 @@
                                      	    "investorId": "9876543210",<br>
                                      	    "creationReason": "New",<br>
                                      	    "accountId": "1234567890",<br>
-                                     	    "firstSubscriptionDate": "2011-03-23"<br>
+                                     	    "firstSubscriptionDate": "2017-04-06"<br>
                                         }
                 </p>
             </td>
@@ -86,7 +86,7 @@
                 <p class ="code--block"> {<br>
                                      	    "investorId": "9876543",<br>
                                      	    "creationReason": "New",<br>
-                                     	    "firstSubscriptionDate": 2011<br>
+                                     	    "firstSubscriptionDate": "2011"<br>
                                         }
                 </p>
             </td>
@@ -116,13 +116,49 @@
             </td>
         </tr>
         <tr>
+            <td><p>Request containing dates before 6 April 2017</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a></p></td>
+            <td>
+                <p class ="code--block"> {<br>
+                                              "investorId": "9876543210",<br>
+                                              "creationReason": "Transferred",<br>
+                                              "accountId": "1234567890",<br>
+                                              "firstSubscriptionDate": "2016-04-06",<br>
+                                              "transferAccount": {<br>
+                                                "transferredFromAccountId": "8765432100",<br>
+                                                "transferredFromLMRN": "Z654321",<br>
+                                                "transferInDate": "2016-04-06"<br>
+                                              }<br>
+                                        }
+                </p>
+            </td>
+            <td><p>HTTP status: <code class="code--slim">403 (Forbidden)</code></p>
+                <p class ="code--block">{<br>
+						  "code": "FORBIDDEN",<br>
+						  "message": "There is a problem with the request data",<br>
+						  "errors": [<br>
+						    {<br>
+						      "code": "INVALID_DATE",<br>
+						      "message": "The firstSubscriptionDate cannot be before 6 April 2017",<br>
+						      "path": "/firstSubscriptionDate"<br>
+						    },<br>
+						    {<br>
+						      "code": "INVALID_DATE",<br>
+						      "message": "The transferInDate cannot be before 6 April 2017",<br>
+						      "path": "/transferAccount/transferInDate"<br>
+						    }
+						  ]<br>
+						}
+                </p>
+            </td>
+        </tr>
+        <tr>
             <td><p>Request containing investor details which can't be found</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a></p></td>
             <td>
                 <p class ="code--block"> {<br>
                                      	    "investorId": "1234567890",<br>
                                      	    "creationReason": "New",<br>
                                      	    "accountId": "1234567890",<br>
-                                     	    "firstSubscriptionDate": "2011-03-23"<br>
+                                     	    "firstSubscriptionDate": "2017-04-06"<br>
                                         }
                 </p>
             </td>
@@ -141,7 +177,7 @@
                                      	    "investorId": "1234567891",<br>
                                      	    "creationReason": "New",<br>
                                      	    "accountId": "1234567890",<br>
-                                     	    "firstSubscriptionDate": "2011-03-23"<br>
+                                     	    "firstSubscriptionDate": "2017-04-06"<br>
                                         }
                 </p>
             </td>
@@ -160,7 +196,7 @@
                                             "investorId": "1234567892",<br>
                                      	    "creationReason": "New",<br>
                                      	    "accountId": "1234567890",<br>
-                                     	    "firstSubscriptionDate": "2011-03-23"<br>
+                                     	    "firstSubscriptionDate": "2017-04-06"<br>
                                         }
                 </p>
             </td>
@@ -179,11 +215,11 @@
                                               "investorId": "1234567889",<br>
                                               "creationReason": "Transferred",<br>
                                               "accountId": "1234567890",<br>
-                                              "firstSubscriptionDate": "2011-03-23",<br>
+                                              "firstSubscriptionDate": "2017-04-06",<br>
                                               "transferAccount": {<br>
                                                 "transferredFromAccountId": "8765432100",<br>
                                                 "transferredFromLMRN": "Z654321",<br>
-                                                "transferInDate": "2015-12-13"<br>
+                                                "transferInDate": "2017-04-06"<br>
                                               }<br>
                                         }
                 </p>
@@ -203,7 +239,7 @@
                                                "investorId":"9876543210",<br>
                                                "creationReason":"Transferred",<br>
                                                "accountId":"1234567890",<br>
-                                               "firstSubscriptionDate":"2011-03-23"<br>
+                                               "firstSubscriptionDate":"2017-04-06"<br>
                                         }
                 </p>
             </td>
@@ -222,11 +258,11 @@
                                      	     "investorId": "9876543210",<br>
                                      	     "creationReason": "New",<br>
                                      	     "accountId": "1234567890",<br>
-                                     	     "firstSubscriptionDate": "2011-03-23",<br>
+                                     	     "firstSubscriptionDate": "2017-04-06",<br>
 	                                          "transferAccount": {<br>
 	                                            "transferredFromAccountId": "8765432100",<br>
 	                                            "transferredFromLMRN": "Z654321",<br>
-	                                            "transferInDate": "2015-12-13"<br>
+	                                            "transferInDate": "2017-04-06"<br>
 	                                          }<br>
                                         }
                 </p>
@@ -246,7 +282,7 @@
                                      	    "investorId": "0000000403",<br>
                                      	    "creationReason": "New",<br>
                                      	    "accountId": "1234567890",<br>
-                                     	    "firstSubscriptionDate": "2011-03-23"<br>
+                                     	    "firstSubscriptionDate": "2017-04-06"<br>
                                         }
                 </p>
             </td>
@@ -265,7 +301,7 @@
                                      	    "investorId": "1000000403",<br>
                                      	    "creationReason": "New",<br>
                                      	    "accountId": "1234567890",<br>
-                                     	    "firstSubscriptionDate": "2011-03-23"<br>
+                                     	    "firstSubscriptionDate": "2017-04-06"<br>
                                         }
                 </p>
             </td>
@@ -284,7 +320,7 @@
                                      	    "investorId": "9876543210",<br>
                                      	    "creationReason": "New",<br>
                                      	    "accountId": "1234567890",<br>
-                                     	    "firstSubscriptionDate": "2011-03-23"<br>
+                                     	    "firstSubscriptionDate": "2017-04-06"<br>
                                         }
                 </p>
             </td>
@@ -303,7 +339,7 @@
                                      	    "investorId": "1234567899",<br>
                                      	    "creationReason": "New",<br>
                                      	    "accountId": "1234567890",<br>
-                                     	    "firstSubscriptionDate": "2011-03-23"<br>
+                                     	    "firstSubscriptionDate": "2017-04-06"<br>
                                         }
                 </p>
             </td>

--- a/resources/public/api/conf/1.0/testdata/life-event.md
+++ b/resources/public/api/conf/1.0/testdata/life-event.md
@@ -77,6 +77,30 @@
             </td>
         </tr>
         <tr>
+            <td><p>Request containing an event date before 6 April 2017</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td>
+                <p class ="code--block"> {<br>
+                                            "eventType" : "LISA Investor Terminal Ill Health",<br>
+                                            "eventDate" : "2017-04-05"<br>
+                                        }
+                </p>
+            </td>
+            <td><p>HTTP status: <code class="code--slim">403 (Forbidden)</code></p>
+                <p class ="code--block"> {<br>
+					  "code": "FORBIDDEN",<br>
+					  "message": "There is a problem with the request data",<br>
+					  "errors": [<br>
+					    {<br>
+					      "code": "INVALID_DATE",<br>
+					      "message": "The eventDate cannot be before 6 April 2017",<br>
+					      "path": "/eventDate"<br>
+					    }<br>
+					  ]<br>
+					}
+                </p>
+            </td>
+        </tr>
+        <tr>
             <td><p>Request containing a life event that conflicts with a previously reported event</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 0000000403</p></td>
             <td>
                 <p class ="code--block"> {<br>

--- a/resources/public/api/conf/1.0/testdata/subscription-update.md
+++ b/resources/public/api/conf/1.0/testdata/subscription-update.md
@@ -92,10 +92,33 @@
             </td>
         </tr>
         <tr>
+            <td><p>Request containing a first subscription date before 6 April 2017</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td>
+                <p class ="code--block"> {<br>
+                                     	  "firstSubscriptionDate": "2017-04-05"<br>
+                                        }
+                </p>
+            </td>
+            <td><p>HTTP status: <code class="code--slim">403 (Forbidden)</code></p>
+                <p class ="code--block"> {<br>
+                                              "code": "FORBIDDEN",<br>
+                                              "message": "There is a problem with the request data",<br>
+                                              "errors": [<br>
+                                                {<br>
+                                                  "code": "INVALID_DATE",<br>
+                                                  "message": "The firstSubscriptionDate cannot be before 6 April 2017",<br>
+                                                  "path": "/firstSubscriptionDate"<br>
+                                                }<br>
+                                              ]<br>
+}
+                </p>
+            </td>
+        </tr>
+        <tr>
             <td><p>Request for an account that has already been closed</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 0000000901</p></td>
             <td>
                 <p class ="code--block"> {<br>
-                                     	  "firstSubscriptionDate": "2017-01-20"<br>
+                                     	  "firstSubscriptionDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -111,7 +134,7 @@
             <td><p>Request for an account that has already been void</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 0000000902</p></td>
             <td>
                 <p class ="code--block"> {<br>
-                                          "firstSubscriptionDate": "2017-01-20"<br>
+                                          "firstSubscriptionDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -127,7 +150,7 @@
             <td><p>Request containing an account ID that does not exist</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 0000000404</p></td>
             <td>
                 <p class ="code--block"> {<br>
-                                     	  "firstSubscriptionDate": "2017-01-20"<br>
+                                     	  "firstSubscriptionDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>
@@ -143,7 +166,7 @@
             <td><p>Request with an invalid 'Accept' header</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
                 <p class ="code--block"> {<br>
-                                          "firstSubscriptionDate": "2017-01-20"<br>
+                                          "firstSubscriptionDate": "2017-05-20"<br>
                                         }
                 </p>
             </td>

--- a/test/unit/controllers/AccountControllerSpec.scala
+++ b/test/unit/controllers/AccountControllerSpec.scala
@@ -51,18 +51,18 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
                             |  "investorId" : "9876543210",
                             |  "accountId" :"8765/432100",
                             |  "creationReason" : "New",
-                            |  "firstSubscriptionDate" : "2011-03-23"
+                            |  "firstSubscriptionDate" : "2017-04-06"
                             |}""".stripMargin
 
   val createAccountJsonWithTransfer = """{
                                         |  "investorId" : "9876543210",
                                         |  "accountId" :"8765/432100",
                                         |  "creationReason" : "New",
-                                        |  "firstSubscriptionDate" : "2011-03-23",
+                                        |  "firstSubscriptionDate" : "2017-04-06",
                                         |  "transferAccount": {
                                         |    "transferredFromAccountId": "Z54/3210",
                                         |    "transferredFromLMRN": "Z543333",
-                                        |    "transferInDate": "2015-12-13"
+                                        |    "transferInDate": "2017-04-06"
                                         |  }
                                         |}""".stripMargin
 
@@ -70,7 +70,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
                                                |  "investorId" : "9876543210",
                                                |  "accountId" :"8765/432100",
                                                |  "creationReason" : "New",
-                                               |  "firstSubscriptionDate" : "2011-03-23",
+                                               |  "firstSubscriptionDate" : "2017-04-06",
                                                |  "transferAccount": "X"
                                                |}""".stripMargin
 
@@ -78,11 +78,11 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
                               |  "investorId" : "9876543210",
                               |  "accountId" :"8765/432100",
                               |  "creationReason" : "Transferred",
-                              |  "firstSubscriptionDate" : "2011-03-23",
+                              |  "firstSubscriptionDate" : "2017-04-06",
                               |  "transferAccount": {
                               |    "transferredFromAccountId": "Z54/3210",
                               |    "transferredFromLMRN": "Z543333",
-                              |    "transferInDate": "2015-12-13"
+                              |    "transferInDate": "2017-04-06"
                               |  }
                               |}""".stripMargin
 
@@ -90,10 +90,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
                                         |  "investorId" : "9876543210",
                                         |  "accountId" :"8765/432100",
                                         |  "creationReason" : "Transferred",
-                                        |  "firstSubscriptionDate" : "2011-03-23"
+                                        |  "firstSubscriptionDate" : "2017-04-06"
                                         |}""".stripMargin
 
-  val closeAccountJson = """{"accountClosureReason" : "All funds withdrawn", "closureDate" : "2000-06-23"}"""
+  val closeAccountJson = """{"accountClosureReason" : "All funds withdrawn", "closureDate" : "2017-04-06"}"""
 
   "The Create / Transfer Account endpoint" must {
 
@@ -110,7 +110,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23"
+              "firstSubscriptionDate" -> "2017-04-06"
             )))(any())
         }
       }
@@ -128,7 +128,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "reasonNotCreated" -> "INVESTOR_NOT_FOUND"
             )))(any())
         }
@@ -144,7 +144,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "reasonNotCreated" -> "INVESTOR_ELIGIBILITY_CHECK_FAILED"
             ))
           )(any())
@@ -161,7 +161,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "reasonNotCreated" -> "INVESTOR_COMPLIANCE_CHECK_FAILED"
             ))
           )(any())
@@ -178,10 +178,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2015-12-13",
+              "transferInDate" -> "2017-04-06",
               "reasonNotCreated" -> "PREVIOUS_INVESTOR_ACCOUNT_DOES_NOT_EXIST"
             ))
           )(any())
@@ -198,7 +198,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_EXISTS"
             ))
           )(any())
@@ -215,7 +215,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "reasonNotCreated" -> "INTERNAL_SERVER_ERROR"
             ))
           )(any())
@@ -234,10 +234,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2015-12-13"
+              "transferInDate" -> "2017-04-06"
             )))(any())
         }
       }
@@ -255,10 +255,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2015-12-13",
+              "transferInDate" -> "2017-04-06",
               "reasonNotCreated" -> "INVESTOR_NOT_FOUND"
             )))(any())
         }
@@ -274,10 +274,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2015-12-13",
+              "transferInDate" -> "2017-04-06",
               "reasonNotCreated" -> "INVESTOR_COMPLIANCE_CHECK_FAILED"
             )))(any())
         }
@@ -293,10 +293,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2015-12-13",
+              "transferInDate" -> "2017-04-06",
               "reasonNotCreated" -> "PREVIOUS_INVESTOR_ACCOUNT_DOES_NOT_EXIST"
             )))(any())
         }
@@ -312,10 +312,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2015-12-13",
+              "transferInDate" -> "2017-04-06",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
             )))(any())
         }
@@ -331,10 +331,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2015-12-13",
+              "transferInDate" -> "2017-04-06",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_VOID"
             )))(any())
         }
@@ -350,10 +350,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2015-12-13",
+              "transferInDate" -> "2017-04-06",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_EXISTS"
             )))(any())
         }
@@ -369,10 +369,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2011-03-23",
+              "firstSubscriptionDate" -> "2017-04-06",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2015-12-13",
+              "transferInDate" -> "2017-04-06",
               "reasonNotCreated" -> "INTERNAL_SERVER_ERROR"
             )))(any())
         }
@@ -643,36 +643,36 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
 
     "return the correct json" when {
       "returning a valid open account response" in {
-        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2011-03-23", "OPEN", "ACTIVE", None, None, None)))
+        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "OPEN", "ACTIVE", None, None, None)))
         doSyncGetAccountDetailsRequest(res => {
           status(res) mustBe OK
-          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2011-03-23", "OPEN", "ACTIVE", None, None, None))
+          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "OPEN", "ACTIVE", None, None, None))
         })
       }
 
       "returning a valid close account response" in {
-        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2011-03-23", "CLOSED", "ACTIVE", Some("All funds withdrawn"), Some("2017-01-03"), None)))
+        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "CLOSED", "ACTIVE", Some("All funds withdrawn"), Some("2017-01-03"), None)))
         doSyncGetAccountDetailsRequest(res => {
           status(res) mustBe OK
-          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2011-03-23",  "CLOSED", "ACTIVE", Some("All funds withdrawn"), Some("2017-01-03"), None))
+          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06",  "CLOSED", "ACTIVE", Some("All funds withdrawn"), Some("2017-01-03"), None))
         })
       }
 
       "returning a valid transfer account response" in {
         when(mockService.getAccount(any(), any())(any())).
-          thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "Transferred", "2011-03-23", "OPEN", "ACTIVE", None, None, Some(GetLisaAccountTransferAccount("8765432102", "Z543333", new DateTime("2015-12-13"))))))
+          thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "Transferred", "2017-04-06", "OPEN", "ACTIVE", None, None, Some(GetLisaAccountTransferAccount("8765432102", "Z543333", new DateTime("2017-04-06"))))))
 
         doSyncGetAccountDetailsRequest(res => {
           status(res) mustBe OK
-          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "Transferred", "2011-03-23", "OPEN", "ACTIVE", None, None, Some(GetLisaAccountTransferAccount("8765432102", "Z543333", new DateTime("2015-12-13")))))
+          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "Transferred", "2017-04-06", "OPEN", "ACTIVE", None, None, Some(GetLisaAccountTransferAccount("8765432102", "Z543333", new DateTime("2017-04-06")))))
         })
       }
 
       "returning a valid void account response" in {
-        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2011-03-23", "VOID", "ACTIVE", None, None, None)))
+        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "VOID", "ACTIVE", None, None, None)))
         doSyncGetAccountDetailsRequest(res => {
           status(res) mustBe OK
-          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2011-03-23", "VOID", "ACTIVE", None, None, None))
+          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "VOID", "ACTIVE", None, None, None))
         })
       }
 
@@ -709,7 +709,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               auditData = matchersEquals(Map(
                 "lisaManagerReferenceNumber" -> lisaManager,
                 "accountClosureReason" -> "All funds withdrawn",
-                "closureDate" -> "2000-06-23",
+                "closureDate" -> "2017-04-06",
                 "accountId" -> accountId
                )))(any())
           }
@@ -728,7 +728,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2000-06-23",
+              "closureDate" -> "2017-04-06",
               "accountId" -> accountId,
               "reasonNotClosed" -> "INVESTOR_ACCOUNT_ALREADY_VOID"
             )))(any())
@@ -745,7 +745,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2000-06-23",
+              "closureDate" -> "2017-04-06",
               "accountId" -> accountId,
               "reasonNotClosed" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
             )))(any())
@@ -762,7 +762,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2000-06-23",
+              "closureDate" -> "2017-04-06",
               "accountId" -> accountId,
               "reasonNotClosed" -> "CANCELLATION_PERIOD_EXCEEDED"
             )))(any())
@@ -779,7 +779,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2000-06-23",
+              "closureDate" -> "2017-04-06",
               "accountId" -> accountId,
               "reasonNotClosed" -> "ACCOUNT_WITHIN_CANCELLATION_PERIOD"
             )))(any())
@@ -796,7 +796,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2000-06-23",
+              "closureDate" -> "2017-04-06",
               "accountId" -> accountId,
               "reasonNotClosed" -> "INVESTOR_ACCOUNTID_NOT_FOUND"
             )))(any())
@@ -815,7 +815,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               auditData = matchersEquals(Map(
                 "lisaManagerReferenceNumber" -> lisaManager,
                 "accountClosureReason" -> "All funds withdrawn",
-                "closureDate" -> "2000-06-23",
+                "closureDate" -> "2017-04-06",
                 "accountId" -> accountId,
                 "reasonNotClosed" -> "INTERNAL_SERVER_ERROR"
               )))(any())

--- a/test/unit/controllers/AccountControllerSpec.scala
+++ b/test/unit/controllers/AccountControllerSpec.scala
@@ -453,7 +453,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
           (json \ "errors" \ 0 \ "path").as[String] mustBe "/firstSubscriptionDate"
         }
       }
-      "given a firstSubscriptionDate and transferInDate prior to 6 April 2017" ignore {
+      "given a firstSubscriptionDate and transferInDate prior to 6 April 2017" in {
         when(mockService.createAccount(any(), any())(any())).thenReturn(Future.successful(CreateLisaAccountSuccessResponse(accountId)))
 
         val invalidJson = transferAccountJson.replace(s"$validDate", "2017-04-05")

--- a/test/unit/controllers/AccountControllerSpec.scala
+++ b/test/unit/controllers/AccountControllerSpec.scala
@@ -855,6 +855,25 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
       }
     }
 
+    "return with status 403 forbidden and a code of FORBIDDEN" when {
+      "given a closure date prior to 6 April 2017" in {
+        when(mockService.closeAccount(any(), any(), any())(any())).thenReturn(Future.successful(CloseLisaAccountSuccessResponse(accountId)))
+
+        val json = closeAccountJson.replace(validDate, "2017-04-05")
+
+        doCloseRequest(json) { res =>
+          status(res) mustBe (FORBIDDEN)
+
+          val json = contentAsJson(res)
+
+          (json \ "code").as[String] mustBe "FORBIDDEN"
+          (json \ "errors" \ 0 \ "code").as[String] mustBe "INVALID_DATE"
+          (json \ "errors" \ 0 \ "message").as[String] mustBe "The closureDate cannot be before 6 April 2017"
+          (json \ "errors" \ 0 \ "path").as[String] mustBe "/closureDate"
+        }
+      }
+    }
+
     "return with status 403 forbidden and a code of INVESTOR_ACCOUNT_ALREADY_VOID" when {
       "the data service returns a CloseLisaAccountAlreadyVoidResponse" in {
         when(mockService.closeAccount(any(), any(), any())(any())).thenReturn(Future.successful(CloseLisaAccountAlreadyVoidResponse))

--- a/test/unit/controllers/AccountControllerSpec.scala
+++ b/test/unit/controllers/AccountControllerSpec.scala
@@ -46,54 +46,56 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
   override def beforeEach() {
     reset(mockAuditService)
   }
+  
+  val validDate = "2017-04-06"
 
-  val createAccountJson = """{
+  val createAccountJson = s"""{
                             |  "investorId" : "9876543210",
                             |  "accountId" :"8765/432100",
                             |  "creationReason" : "New",
-                            |  "firstSubscriptionDate" : "2017-04-06"
+                            |  "firstSubscriptionDate" : "$validDate"
                             |}""".stripMargin
 
-  val createAccountJsonWithTransfer = """{
+  val createAccountJsonWithTransfer = s"""{
                                         |  "investorId" : "9876543210",
                                         |  "accountId" :"8765/432100",
                                         |  "creationReason" : "New",
-                                        |  "firstSubscriptionDate" : "2017-04-06",
+                                        |  "firstSubscriptionDate" : "$validDate",
                                         |  "transferAccount": {
                                         |    "transferredFromAccountId": "Z54/3210",
                                         |    "transferredFromLMRN": "Z543333",
-                                        |    "transferInDate": "2017-04-06"
+                                        |    "transferInDate": "$validDate"
                                         |  }
                                         |}""".stripMargin
 
-  val createAccountJsonWithInvalidTransfer = """{
+  val createAccountJsonWithInvalidTransfer = s"""{
                                                |  "investorId" : "9876543210",
                                                |  "accountId" :"8765/432100",
                                                |  "creationReason" : "New",
-                                               |  "firstSubscriptionDate" : "2017-04-06",
+                                               |  "firstSubscriptionDate" : "$validDate",
                                                |  "transferAccount": "X"
                                                |}""".stripMargin
 
-  val transferAccountJson = """{
+  val transferAccountJson = s"""{
                               |  "investorId" : "9876543210",
                               |  "accountId" :"8765/432100",
                               |  "creationReason" : "Transferred",
-                              |  "firstSubscriptionDate" : "2017-04-06",
+                              |  "firstSubscriptionDate" : "$validDate",
                               |  "transferAccount": {
                               |    "transferredFromAccountId": "Z54/3210",
                               |    "transferredFromLMRN": "Z543333",
-                              |    "transferInDate": "2017-04-06"
+                              |    "transferInDate": "$validDate"
                               |  }
                               |}""".stripMargin
 
-  val transferAccountJsonIncomplete = """{
+  val transferAccountJsonIncomplete = s"""{
                                         |  "investorId" : "9876543210",
                                         |  "accountId" :"8765/432100",
                                         |  "creationReason" : "Transferred",
-                                        |  "firstSubscriptionDate" : "2017-04-06"
+                                        |  "firstSubscriptionDate" : "$validDate"
                                         |}""".stripMargin
 
-  val closeAccountJson = """{"accountClosureReason" : "All funds withdrawn", "closureDate" : "2017-04-06"}"""
+  val closeAccountJson = s"""{"accountClosureReason" : "All funds withdrawn", "closureDate" : "$validDate"}"""
 
   "The Create / Transfer Account endpoint" must {
 
@@ -110,7 +112,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06"
+              "firstSubscriptionDate" -> s"$validDate"
             )))(any())
         }
       }
@@ -128,7 +130,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "reasonNotCreated" -> "INVESTOR_NOT_FOUND"
             )))(any())
         }
@@ -144,7 +146,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "reasonNotCreated" -> "INVESTOR_ELIGIBILITY_CHECK_FAILED"
             ))
           )(any())
@@ -161,7 +163,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "reasonNotCreated" -> "INVESTOR_COMPLIANCE_CHECK_FAILED"
             ))
           )(any())
@@ -178,10 +180,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2017-04-06",
+              "transferInDate" -> s"$validDate",
               "reasonNotCreated" -> "PREVIOUS_INVESTOR_ACCOUNT_DOES_NOT_EXIST"
             ))
           )(any())
@@ -198,7 +200,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_EXISTS"
             ))
           )(any())
@@ -215,7 +217,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "reasonNotCreated" -> "INTERNAL_SERVER_ERROR"
             ))
           )(any())
@@ -234,10 +236,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2017-04-06"
+              "transferInDate" -> s"$validDate"
             )))(any())
         }
       }
@@ -255,10 +257,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2017-04-06",
+              "transferInDate" -> s"$validDate",
               "reasonNotCreated" -> "INVESTOR_NOT_FOUND"
             )))(any())
         }
@@ -274,10 +276,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2017-04-06",
+              "transferInDate" -> s"$validDate",
               "reasonNotCreated" -> "INVESTOR_COMPLIANCE_CHECK_FAILED"
             )))(any())
         }
@@ -293,10 +295,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2017-04-06",
+              "transferInDate" -> s"$validDate",
               "reasonNotCreated" -> "PREVIOUS_INVESTOR_ACCOUNT_DOES_NOT_EXIST"
             )))(any())
         }
@@ -312,10 +314,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2017-04-06",
+              "transferInDate" -> s"$validDate",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
             )))(any())
         }
@@ -331,10 +333,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2017-04-06",
+              "transferInDate" -> s"$validDate",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_VOID"
             )))(any())
         }
@@ -350,10 +352,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2017-04-06",
+              "transferInDate" -> s"$validDate",
               "reasonNotCreated" -> "INVESTOR_ACCOUNT_ALREADY_EXISTS"
             )))(any())
         }
@@ -369,10 +371,10 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               "lisaManagerReferenceNumber" -> lisaManager,
               "investorId" -> "9876543210",
               "accountId" -> "8765/432100",
-              "firstSubscriptionDate" -> "2017-04-06",
+              "firstSubscriptionDate" -> s"$validDate",
               "transferredFromAccountId" -> "Z54/3210",
               "transferredFromLMRN" -> "Z543333",
-              "transferInDate" -> "2017-04-06",
+              "transferInDate" -> s"$validDate",
               "reasonNotCreated" -> "INTERNAL_SERVER_ERROR"
             )))(any())
         }
@@ -430,6 +432,44 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
 
           errors must contain(Json.obj("code" -> "INVALID_FORMAT", "message" -> "Invalid format has been used", "path" -> "/accountId"))
           errors must contain(Json.obj("code" -> "INVALID_FORMAT", "message" -> "Invalid format has been used", "path" -> "/transferAccount/transferredFromAccountId"))
+        }
+      }
+    }
+    
+    "return with status 403 forbidden and a code of FORBIDDEN" when {
+      "given a firstSubscriptionDate prior to 6 April 2017" in {
+        when(mockService.createAccount(any(), any())(any())).thenReturn(Future.successful(CreateLisaAccountSuccessResponse(accountId)))
+
+        val invalidJson = createAccountJson.replace(s"$validDate", "2017-04-05")
+
+        doCreateOrTransferRequest(invalidJson) { res =>
+          status(res) mustBe (FORBIDDEN)
+
+          val json = contentAsJson(res)
+
+          (json \ "code").as[String] mustBe "FORBIDDEN"
+          (json \ "errors" \ 0 \ "code").as[String] mustBe "INVALID_DATE"
+          (json \ "errors" \ 0 \ "message").as[String] mustBe "The firstSubscriptionDate cannot be before 6 April 2017"
+          (json \ "errors" \ 0 \ "path").as[String] mustBe "/firstSubscriptionDate"
+        }
+      }
+      "given a firstSubscriptionDate and transferInDate prior to 6 April 2017" ignore {
+        when(mockService.createAccount(any(), any())(any())).thenReturn(Future.successful(CreateLisaAccountSuccessResponse(accountId)))
+
+        val invalidJson = transferAccountJson.replace(s"$validDate", "2017-04-05")
+
+        doCreateOrTransferRequest(invalidJson) { res =>
+          status(res) mustBe (FORBIDDEN)
+
+          val json = contentAsJson(res)
+
+          (json \ "code").as[String] mustBe "FORBIDDEN"
+          (json \ "errors" \ 0 \ "code").as[String] mustBe "INVALID_DATE"
+          (json \ "errors" \ 0 \ "message").as[String] mustBe "The firstSubscriptionDate cannot be before 6 April 2017"
+          (json \ "errors" \ 0 \ "path").as[String] mustBe "/firstSubscriptionDate"
+          (json \ "errors" \ 1 \ "code").as[String] mustBe "INVALID_DATE"
+          (json \ "errors" \ 1 \ "message").as[String] mustBe "The transferInDate cannot be before 6 April 2017"
+          (json \ "errors" \ 1 \ "path").as[String] mustBe "/transferAccount/transferInDate"
         }
       }
     }
@@ -625,14 +665,6 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
           status(res) mustBe (INTERNAL_SERVER_ERROR)
         }
       }
-
-      "the data service returns a GetLisaAccountErrorResponse for a getAccount details request" in {
-        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountErrorResponse))
-
-        doSyncGetAccountDetailsRequest { res =>
-          status(res) mustBe (INTERNAL_SERVER_ERROR)
-        }
-      }
     }
 
   }
@@ -643,46 +675,41 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
 
     "return the correct json" when {
       "returning a valid open account response" in {
-        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "OPEN", "ACTIVE", None, None, None)))
+        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", s"$validDate", "OPEN", "ACTIVE", None, None, None)))
         doSyncGetAccountDetailsRequest(res => {
           status(res) mustBe OK
-          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "OPEN", "ACTIVE", None, None, None))
+          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", s"$validDate", "OPEN", "ACTIVE", None, None, None))
         })
       }
-
       "returning a valid close account response" in {
-        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "CLOSED", "ACTIVE", Some("All funds withdrawn"), Some("2017-01-03"), None)))
+        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", s"$validDate", "CLOSED", "ACTIVE", Some("All funds withdrawn"), Some("2017-01-03"), None)))
         doSyncGetAccountDetailsRequest(res => {
           status(res) mustBe OK
-          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06",  "CLOSED", "ACTIVE", Some("All funds withdrawn"), Some("2017-01-03"), None))
+          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", s"$validDate",  "CLOSED", "ACTIVE", Some("All funds withdrawn"), Some("2017-01-03"), None))
         })
       }
-
       "returning a valid transfer account response" in {
         when(mockService.getAccount(any(), any())(any())).
-          thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "Transferred", "2017-04-06", "OPEN", "ACTIVE", None, None, Some(GetLisaAccountTransferAccount("8765432102", "Z543333", new DateTime("2017-04-06"))))))
+          thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "Transferred", s"$validDate", "OPEN", "ACTIVE", None, None, Some(GetLisaAccountTransferAccount("8765432102", "Z543333", new DateTime(s"$validDate"))))))
 
         doSyncGetAccountDetailsRequest(res => {
           status(res) mustBe OK
-          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "Transferred", "2017-04-06", "OPEN", "ACTIVE", None, None, Some(GetLisaAccountTransferAccount("8765432102", "Z543333", new DateTime("2017-04-06")))))
+          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "Transferred", s"$validDate", "OPEN", "ACTIVE", None, None, Some(GetLisaAccountTransferAccount("8765432102", "Z543333", new DateTime(s"$validDate")))))
         })
       }
-
       "returning a valid void account response" in {
-        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "VOID", "ACTIVE", None, None, None)))
+        when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", s"$validDate", "VOID", "ACTIVE", None, None, None)))
         doSyncGetAccountDetailsRequest(res => {
           status(res) mustBe OK
-          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", "2017-04-06", "VOID", "ACTIVE", None, None, None))
+          contentAsJson(res) mustBe Json.toJson (GetLisaAccountSuccessResponse("9876543210", "8765432100", "New", s"$validDate", "VOID", "ACTIVE", None, None, None))
         })
       }
-
       "returning a account not found response" in {
         when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountDoesNotExistResponse))
         doSyncGetAccountDetailsRequest(res => {
           (contentAsJson(res) \ "code").as[String] mustBe "INVESTOR_ACCOUNTID_NOT_FOUND"
         })
       }
-
       "returning a internal server error response" in {
         when(mockService.getAccount(any(), any())(any())).thenReturn(Future.successful(GetLisaAccountErrorResponse))
         doSyncGetAccountDetailsRequest(res => {
@@ -709,7 +736,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
               auditData = matchersEquals(Map(
                 "lisaManagerReferenceNumber" -> lisaManager,
                 "accountClosureReason" -> "All funds withdrawn",
-                "closureDate" -> "2017-04-06",
+                "closureDate" -> s"$validDate",
                 "accountId" -> accountId
                )))(any())
           }
@@ -728,13 +755,12 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2017-04-06",
+              "closureDate" -> s"$validDate",
               "accountId" -> accountId,
               "reasonNotClosed" -> "INVESTOR_ACCOUNT_ALREADY_VOID"
             )))(any())
         }
       }
-
       "the data service returns a CloseLisaAccountAlreadyClosedResponse" in {
         when(mockService.closeAccount(any(), any(), any())(any())).thenReturn(Future.successful(CloseLisaAccountAlreadyClosedResponse))
 
@@ -745,13 +771,12 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2017-04-06",
+              "closureDate" -> s"$validDate",
               "accountId" -> accountId,
               "reasonNotClosed" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
             )))(any())
         }
       }
-
       "the data service returns a CloseLisaAccountCancellationPeriodExceeded" in {
         when(mockService.closeAccount(any(), any(), any())(any())).thenReturn(Future.successful(CloseLisaAccountCancellationPeriodExceeded))
 
@@ -762,13 +787,12 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2017-04-06",
+              "closureDate" -> s"$validDate",
               "accountId" -> accountId,
               "reasonNotClosed" -> "CANCELLATION_PERIOD_EXCEEDED"
             )))(any())
         }
       }
-
       "the data service returns a CloseLisaAccountWithinCancellationPeriod" in {
         when(mockService.closeAccount(any(), any(), any())(any())).thenReturn(Future.successful(CloseLisaAccountWithinCancellationPeriod))
 
@@ -779,13 +803,12 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2017-04-06",
+              "closureDate" -> s"$validDate",
               "accountId" -> accountId,
               "reasonNotClosed" -> "ACCOUNT_WITHIN_CANCELLATION_PERIOD"
             )))(any())
         }
       }
-
       "the data service returns a CloseLisaAccountNotFoundResponse" in {
         when(mockService.closeAccount(any(), any(), any())(any())).thenReturn(Future.successful(CloseLisaAccountNotFoundResponse))
 
@@ -796,31 +819,28 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountClosureReason" -> "All funds withdrawn",
-              "closureDate" -> "2017-04-06",
+              "closureDate" -> s"$validDate",
               "accountId" -> accountId,
               "reasonNotClosed" -> "INVESTOR_ACCOUNTID_NOT_FOUND"
             )))(any())
 
         }
       }
+      "the data service returns a CloseLisaAccountErrorResponse" in {
+        when(mockService.closeAccount(any(), any(), any())(any())).thenReturn(Future.successful(CloseLisaAccountErrorResponse))
 
-      "return with status 500 internal server error" when {
-        "the data service returns an error" in {
-          when(mockService.closeAccount(any(), any(), any())(any())).thenReturn(Future.successful(CloseLisaAccountErrorResponse))
+        doSyncCloseRequest(closeAccountJson) { res =>
+          verify(mockAuditService).audit(
+            auditType = matchersEquals("accountNotClosed"),
+            path=matchersEquals(s"/manager/$lisaManager/accounts/$accountId/close-account"),
+            auditData = matchersEquals(Map(
+              "lisaManagerReferenceNumber" -> lisaManager,
+              "accountClosureReason" -> "All funds withdrawn",
+              "closureDate" -> s"$validDate",
+              "accountId" -> accountId,
+              "reasonNotClosed" -> "INTERNAL_SERVER_ERROR"
+            )))(any())
 
-          doSyncCloseRequest(closeAccountJson) { res =>
-            verify(mockAuditService).audit(
-              auditType = matchersEquals("accountNotClosed"),
-              path=matchersEquals(s"/manager/$lisaManager/accounts/$accountId/close-account"),
-              auditData = matchersEquals(Map(
-                "lisaManagerReferenceNumber" -> lisaManager,
-                "accountClosureReason" -> "All funds withdrawn",
-                "closureDate" -> "2017-04-06",
-                "accountId" -> accountId,
-                "reasonNotClosed" -> "INTERNAL_SERVER_ERROR"
-              )))(any())
-
-          }
         }
       }
     }
@@ -914,8 +934,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
           status(res) mustBe (INTERNAL_SERVER_ERROR)
         }
       }
-
-      "An exception is thrown" in {
+      "an exception is thrown" in {
         when(mockService.closeAccount(any(), any(), any())(any())).thenThrow(new RuntimeException("Test"))
 
         doCloseRequest(closeAccountJson) { res =>

--- a/test/unit/controllers/BonusPaymentControllerSpec.scala
+++ b/test/unit/controllers/BonusPaymentControllerSpec.scala
@@ -122,7 +122,12 @@ class BonusPaymentControllerSpec extends PlaySpec
 
         val ibp = validBonusPayment.inboundPayments.copy(newSubsForPeriod = Some(1), newSubsYTD = 0, totalSubsForPeriod = 0)
         val htb = validBonusPayment.htbTransfer.get.copy(htbTransferInForPeriod = 1, htbTransferTotalYTD = 0)
-        val request = validBonusPayment.copy(inboundPayments = ibp, htbTransfer = Some(htb))
+        val request = validBonusPayment.copy(
+                        inboundPayments = ibp,
+                        htbTransfer = Some(htb),
+                        periodStartDate = new DateTime(2017,3,6,0,0),
+                        periodEndDate = new DateTime(2017,4,5,0,0)
+        )
 
         doRequest(Json.toJson(request).toString()) { res =>
           status(res) mustBe FORBIDDEN
@@ -131,12 +136,11 @@ class BonusPaymentControllerSpec extends PlaySpec
 
           (json \ "code").as[String] mustBe "FORBIDDEN"
 
-          val errors = (json \ "errors").as[List[Map[String, String]]]
-
-          errors.size mustBe 3
-          errors(0)("path") mustBe "/inboundPayments/newSubsYTD"
-          errors(1)("path") mustBe "/htbTransfer/htbTransferTotalYTD"
-          errors(2)("path") mustBe "/inboundPayments/totalSubsForPeriod"
+          (json \ "errors" \ 0 \ "path").as[String] mustBe "/inboundPayments/newSubsYTD"
+          (json \ "errors" \ 1 \ "path").as[String] mustBe "/htbTransfer/htbTransferTotalYTD"
+          (json \ "errors" \ 2 \ "path").as[String] mustBe "/inboundPayments/totalSubsForPeriod"
+          (json \ "errors" \ 3 \ "path").as[String] mustBe "/periodStartDate"
+          (json \ "errors" \ 4 \ "path").as[String] mustBe "/periodEndDate"
         }
       }
 

--- a/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
+++ b/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
@@ -160,7 +160,10 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
 
         doUpdateSubsDate(invalidJson) { res =>
           status(res) mustBe (BAD_REQUEST)
-          (contentAsJson(res) \ "code").as[String] mustBe ("BAD_REQUEST")
+          val json = contentAsJson(res)
+          (json \ "code").as[String] mustBe ("BAD_REQUEST")
+          (json \ "errors" \ 0 \ "code").as[String] mustBe ("INVALID_DATE")
+          (json \ "errors" \ 0 \ "path").as[String] mustBe ("/firstSubscriptionDate")
         }
       }
       "an invalid lmrn is sent" in {
@@ -171,6 +174,19 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
           val json = contentAsJson(res)
           (json \ "code").as[String] mustBe ErrorBadRequestLmrn.errorCode
           (json \ "message").as[String] mustBe ErrorBadRequestLmrn.message
+        }
+      }
+    }
+    "return with status 403 forbidden and a code of FORBIDDEN" ignore {
+      "an invalid date is sent" in {
+        val invalidJson = updateFirstSubscriptionDate.replace("2015-05-05", "")
+
+        doUpdateSubsDate(invalidJson) { res =>
+          status(res) mustBe (FORBIDDEN)
+          val json = contentAsJson(res)
+          (json \ "code").as[String] mustBe ("FORBIDDEN")
+          (json \ "errors" \ 0 \ "code").as[String] mustBe ("INVALID_DATE")
+          (json \ "errors" \ 0 \ "path").as[String] mustBe ("/firstSubscriptionDate")
         }
       }
     }

--- a/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
+++ b/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
@@ -44,28 +44,28 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
   val accountId = "1234/567890"
   val mockAuthCon = mock[LisaAuthConnector]
 
-  implicit val hc:HeaderCarrier = HeaderCarrier()
+  implicit val hc: HeaderCarrier = HeaderCarrier()
 
   override def beforeEach() {
     reset(mockAuditService)
-    when(mockAuthCon.authorise[Option[String]](any(),any())(any(), any())).thenReturn(Future(Some("1234")))
+    when(mockAuthCon.authorise[Option[String]](any(), any())(any(), any())).thenReturn(Future(Some("1234")))
   }
 
-  val updateFirstSubscriptionDate = """{
-                            |  "firstSubscriptionDate" : "2017-05-05"
-                            |}""".stripMargin
-
+  val updateFirstSubscriptionDate =
+    """{
+      |  "firstSubscriptionDate" : "2017-05-05"
+      |}""".stripMargin
 
   "The update first subscription date endpoint" must {
-    "audit an firstSubscriptionDateUpdate event" when {
-      "submitted a valid first subscription update request" in {
+    "audit a firstSubscriptionDateUpdated event" when {
+      "the data service returns a UpdateSubscriptionSuccessResponse" in {
         when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionSuccessResponse("code", "message")))
         doUpdateSubsDate(updateFirstSubscriptionDate) { result =>
           await(result)
 
           verify(mockAuditService).audit(
             auditType = matchersEquals("firstSubscriptionDateUpdated"),
-            path= matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountID" -> accountId,
@@ -75,18 +75,15 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
         }
       }
     }
+    "audit a firstSubscriptionDateNotUpdated event" when {
+      "the data service returns a UpdateFirstSubscriptionDateAccountAlreadyVoidedResponse" in {
+        when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountVoidedResponse))
 
-
-
-
-    "the data service returns a UpdateFirstSubscriptionDateAccountAlreadyVoidedResponse for a create request" in {
-        when(mockService.updateSubscription(any(), any(),any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountVoidedResponse))
-
-        doUpdateSubsDate(updateFirstSubscriptionDate) {result =>
+        doUpdateSubsDate(updateFirstSubscriptionDate) { result =>
           await(result)
           verify(mockAuditService).audit(
             auditType = matchersEquals("firstSubscriptionDateNotUpdated"),
-            path= matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountID" -> accountId,
@@ -96,32 +93,31 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
           )(any())
         }
       }
+      "the data service returns a UpdateFirstSubscriptionDateAccountAlreadyClosedResponse" in {
+        when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountClosedResponse))
 
-    "the data service returns a UpdateFirstSubscriptionDateAccountAlreadyClosedResponse for a create request" in {
-      when(mockService.updateSubscription(any(), any(),any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountClosedResponse))
-
-      doUpdateSubsDate(updateFirstSubscriptionDate) {result =>
-        await(result)
-        verify(mockAuditService).audit(
-          auditType = matchersEquals("firstSubscriptionDateNotUpdated"),
-          path= matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
-          auditData = matchersEquals(Map(
-            "lisaManagerReferenceNumber" -> lisaManager,
-            "accountID" -> accountId,
-            "firstSubscriptionDate" -> "2017-05-05",
-            "reasonNotUpdated" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
-          ))
-        )(any())
-      }
-    }
-      "the data service returns a UpdateFirstSubscriptionDateAccountNotFound for a create request" in {
-        when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountNotFoundResponse))
-
-        doUpdateSubsDate(updateFirstSubscriptionDate) {result =>
+        doUpdateSubsDate(updateFirstSubscriptionDate) { result =>
           await(result)
           verify(mockAuditService).audit(
             auditType = matchersEquals("firstSubscriptionDateNotUpdated"),
-            path= matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
+            auditData = matchersEquals(Map(
+              "lisaManagerReferenceNumber" -> lisaManager,
+              "accountID" -> accountId,
+              "firstSubscriptionDate" -> "2017-05-05",
+              "reasonNotUpdated" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
+            ))
+          )(any())
+        }
+      }
+      "the data service returns a UpdateFirstSubscriptionDateAccountNotFound" in {
+        when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountNotFoundResponse))
+
+        doUpdateSubsDate(updateFirstSubscriptionDate) { result =>
+          await(result)
+          verify(mockAuditService).audit(
+            auditType = matchersEquals("firstSubscriptionDateNotUpdated"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountID" -> accountId,
@@ -134,11 +130,11 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
       "the data service returns a UpdateFirstSubscriptionDateErrorResponse" in {
         when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionErrorResponse))
 
-        doUpdateSubsDate(updateFirstSubscriptionDate) {result =>
+        doUpdateSubsDate(updateFirstSubscriptionDate) { result =>
           await(result)
           verify(mockAuditService).audit(
             auditType = matchersEquals("firstSubscriptionDateNotUpdated"),
-            path= matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountID" -> accountId,
@@ -149,7 +145,6 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
         }
       }
     }
-
     "return with status 200 created and an account Id" when {
       "submitted a valid update subscription request request and response UPDATED" in {
         when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionSuccessResponse("UPDATED", "message")))
@@ -158,8 +153,6 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
         }
       }
     }
-
-
     "return with status 400 bad request and a code of BAD_REQUEST" when {
       "invalid json is sent" in {
         val invalidJson = updateFirstSubscriptionDate.replace("2017-05-05", "")
@@ -170,7 +163,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
         }
       }
       "invalid lmrn is sent" in {
-        when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionSuccessResponse("code","message")))
+        when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionSuccessResponse("code", "message")))
 
         doUpdateSubsDateInvalidLMRN(updateFirstSubscriptionDate) { res =>
           status(res) mustBe (BAD_REQUEST)
@@ -180,9 +173,28 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
         }
       }
     }
+    "return with status 403 forbidden and a code of INVESTOR_ACCOUNT_ALREADY_CLOSED" when {
+      "the data service returns a UpdateSubscriptionAccountClosedResponse" in {
+        when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountClosedResponse))
 
-    "return with status 403 forbidden and a code" when {
-      "the data service returns a UpdateFirstSubscriptionDateAccountNotFound for a update request" in {
+        doUpdateSubsDate(updateFirstSubscriptionDate) { res =>
+          status(res) mustBe (FORBIDDEN)
+          (contentAsJson(res) \ "code").as[String] mustBe ("INVESTOR_ACCOUNT_ALREADY_CLOSED")
+        }
+      }
+    }
+    "return with status 403 forbidden and a code of INVESTOR_ACCOUNT_ALREADY_VOID" when {
+      "the data service returns a UpdateSubscriptionAccountVoidedResponse" in {
+        when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountVoidedResponse))
+
+        doUpdateSubsDate(updateFirstSubscriptionDate) { res =>
+          status(res) mustBe (FORBIDDEN)
+          (contentAsJson(res) \ "code").as[String] mustBe ("INVESTOR_ACCOUNT_ALREADY_VOID")
+        }
+      }
+    }
+    "return with status 404 not found and a code of INVESTOR_ACCOUNTID_NOT_FOUND" when {
+      "the data service returns a UpdateFirstSubscriptionDateAccountNotFound" in {
         when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountNotFoundResponse))
 
         doUpdateSubsDate(updateFirstSubscriptionDate) { res =>
@@ -192,41 +204,16 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
         }
       }
     }
-    "return with status 403 forbidden and a code of INVESTOR_ACCOUNT_ALREADY_CLOSED_OR_VOID" when {
-      "the data service returns a UpdateFirstSubscriptionDateAccountAlreadyClosedOrVoidedResponse for a create request" in {
-        when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountClosedResponse))
-
-        doUpdateSubsDate(updateFirstSubscriptionDate) { res =>
-          status(res) mustBe (FORBIDDEN)
-          (contentAsJson(res) \ "code").as[String] mustBe ("INVESTOR_ACCOUNT_ALREADY_CLOSED")
-        }
-      }
-
-    }
-
-  "return with status 403 forbidden and a code of INVESTOR_ACCOUNT_ALREADY_VOID" when {
-    "the data service returns a UpdateFirstSubscriptionDateAccountAlreadyClosedOrVoidedResponse for a create request" in {
-      when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountVoidedResponse))
-
-      doUpdateSubsDate(updateFirstSubscriptionDate) { res =>
-        status(res) mustBe (FORBIDDEN)
-        (contentAsJson(res) \ "code").as[String] mustBe ("INVESTOR_ACCOUNT_ALREADY_VOID")
-      }
-    }
-
-  }
-
     "return with status 500 internal server error" when {
-      "the data service returns an error for a create request" in {
+      "the data service returns an error" in {
         when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionErrorResponse))
 
         doUpdateSubsDate(updateFirstSubscriptionDate) { res =>
           status(res) mustBe (INTERNAL_SERVER_ERROR)
         }
       }
+    }
   }
-
-
 
   def doUpdateSubsDate(jsonString: String)(callback: (Future[Result]) => Unit) {
     val res = SUT.updateSubscription(lisaManager, accountId).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
@@ -235,14 +222,12 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
     callback(res)
   }
 
-
   def doUpdateSubsDateInvalidLMRN(jsonString: String)(callback: (Future[Result]) => Unit) {
     val res = SUT.updateSubscription("12345678", accountId).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).
       withBody(AnyContentAsJson(Json.parse(jsonString))))
 
     callback(res)
   }
-
 
   val mockService: UpdateSubscriptionService = mock[UpdateSubscriptionService]
   val mockAuditService: AuditService = mock[AuditService]

--- a/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
+++ b/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
@@ -76,6 +76,21 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
       }
     }
     "audit a firstSubscriptionDateNotUpdated event" when {
+      "the json fails date validation" in {
+        doUpdateSubsDate(updateFirstSubscriptionDate.replace("2017-04-06", "2017-04-05")) { result =>
+          await(result)
+          verify(mockAuditService).audit(
+            auditType = matchersEquals("firstSubscriptionDateNotUpdated"),
+            path = matchersEquals(s"/manager/$lisaManager/accounts/$accountId/update-subscription"),
+            auditData = matchersEquals(Map(
+              "lisaManagerReferenceNumber" -> lisaManager,
+              "accountID" -> accountId,
+              "firstSubscriptionDate" -> "2017-04-05",
+              "reasonNotUpdated" -> "FORBIDDEN"
+            ))
+          )(any())
+        }
+      }
       "the data service returns a UpdateFirstSubscriptionDateAccountAlreadyVoidedResponse" in {
         when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionAccountVoidedResponse))
 

--- a/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
+++ b/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
@@ -145,11 +145,12 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
         }
       }
     }
-    "return with status 200 created and an account Id" when {
-      "submitted a valid update subscription request request and response UPDATED" in {
+    "return with status 200 ok and an account Id" when {
+      "the data service returns a UpdateSubscriptionSuccessResponse" in {
         when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionSuccessResponse("UPDATED", "message")))
         doUpdateSubsDate(updateFirstSubscriptionDate) { res =>
           status(res) mustBe (OK)
+          (contentAsJson(res) \ "data" \ "accountId").as[String] mustBe accountId
         }
       }
     }
@@ -162,7 +163,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
           (contentAsJson(res) \ "code").as[String] mustBe ("BAD_REQUEST")
         }
       }
-      "invalid lmrn is sent" in {
+      "an invalid lmrn is sent" in {
         when(mockService.updateSubscription(any(), any(), any())(any())).thenReturn(Future.successful(UpdateSubscriptionSuccessResponse("code", "message")))
 
         doUpdateSubsDateInvalidLMRN(updateFirstSubscriptionDate) { res =>

--- a/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
+++ b/test/unit/controllers/UpdateFirstSubscriptionDateSpec.scala
@@ -53,7 +53,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
 
   val updateFirstSubscriptionDate =
     """{
-      |  "firstSubscriptionDate" : "2017-05-05"
+      |  "firstSubscriptionDate" : "2017-04-06"
       |}""".stripMargin
 
   "The update first subscription date endpoint" must {
@@ -69,7 +69,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountID" -> accountId,
-              "firstSubscriptionDate" -> "2017-05-05"
+              "firstSubscriptionDate" -> "2017-04-06"
             ))
           )(any())
         }
@@ -87,7 +87,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountID" -> accountId,
-              "firstSubscriptionDate" -> "2017-05-05",
+              "firstSubscriptionDate" -> "2017-04-06",
               "reasonNotUpdated" -> "INVESTOR_ACCOUNT_ALREADY_VOID"
             ))
           )(any())
@@ -104,7 +104,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountID" -> accountId,
-              "firstSubscriptionDate" -> "2017-05-05",
+              "firstSubscriptionDate" -> "2017-04-06",
               "reasonNotUpdated" -> "INVESTOR_ACCOUNT_ALREADY_CLOSED"
             ))
           )(any())
@@ -121,7 +121,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountID" -> accountId,
-              "firstSubscriptionDate" -> "2017-05-05",
+              "firstSubscriptionDate" -> "2017-04-06",
               "reasonNotUpdated" -> "INVESTOR_ACCOUNTID_NOT_FOUND"
             ))
           )(any())
@@ -138,7 +138,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
             auditData = matchersEquals(Map(
               "lisaManagerReferenceNumber" -> lisaManager,
               "accountID" -> accountId,
-              "firstSubscriptionDate" -> "2017-05-05",
+              "firstSubscriptionDate" -> "2017-04-06",
               "reasonNotUpdated" -> "INTERNAL_SERVER_ERROR"
             ))
           )(any())
@@ -156,7 +156,7 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
     }
     "return with status 400 bad request and a code of BAD_REQUEST" when {
       "invalid json is sent" in {
-        val invalidJson = updateFirstSubscriptionDate.replace("2017-05-05", "")
+        val invalidJson = updateFirstSubscriptionDate.replace("2017-04-06", "")
 
         doUpdateSubsDate(invalidJson) { res =>
           status(res) mustBe (BAD_REQUEST)
@@ -177,9 +177,9 @@ class UpdateFirstSubscriptionDateSpec extends PlaySpec with MockitoSugar with On
         }
       }
     }
-    "return with status 403 forbidden and a code of FORBIDDEN" ignore {
+    "return with status 403 forbidden and a code of FORBIDDEN" when {
       "an invalid date is sent" in {
-        val invalidJson = updateFirstSubscriptionDate.replace("2015-05-05", "")
+        val invalidJson = updateFirstSubscriptionDate.replace("2017-04-06", "2017-04-05")
 
         doUpdateSubsDate(invalidJson) { res =>
           status(res) mustBe (FORBIDDEN)

--- a/test/unit/utils/BonusPaymentValidatorSpec.scala
+++ b/test/unit/utils/BonusPaymentValidatorSpec.scala
@@ -228,7 +228,9 @@ class BonusPaymentValidatorSpec extends PlaySpec
     "return an error" when {
 
       "it is not the 6th day of the month" in {
-        val request = validBonusPayment.copy(periodStartDate = new DateTime("2017-04-01"))
+        val periodStartDate = new DateTime("2017-05-01")
+        val periodEndDate = new DateTime("2017-06-05")
+        val request = validBonusPayment.copy(periodStartDate = periodStartDate, periodEndDate = periodEndDate)
 
         val errors = SUT.validate(request)
 
@@ -257,6 +259,22 @@ class BonusPaymentValidatorSpec extends PlaySpec
         )
       }
 
+      "the supplied date is prior to 6 April 2017" in {
+        val periodStartDate = new DateTime("2017-03-06")
+        val periodEndDate = new DateTime("2017-04-05")
+        val request = validBonusPayment.copy(periodStartDate = periodStartDate, periodEndDate = periodEndDate)
+
+        val errors = SUT.validate(request)
+
+        errors must contain(
+          ErrorValidation(
+            errorCode = "INVALID_DATE",
+            message = "The periodStartDate cannot be before 6 April 2017",
+            path = Some("/periodStartDate")
+          )
+        )
+      }
+
     }
 
   }
@@ -266,8 +284,8 @@ class BonusPaymentValidatorSpec extends PlaySpec
     "validate correctly" when {
 
       "the end date crosses into another year" in {
-        val periodStartDate = new DateTime("2016-12-06")
-        val periodEndDate = new DateTime("2017-01-05")
+        val periodStartDate = new DateTime("2017-12-06")
+        val periodEndDate = new DateTime("2018-01-05")
         val request = validBonusPayment.copy(periodStartDate = periodStartDate, periodEndDate = periodEndDate)
 
         val errors = SUT.validate(request)
@@ -294,8 +312,8 @@ class BonusPaymentValidatorSpec extends PlaySpec
       }
 
       "it is two months after the periodStartDate" in {
-        val periodStartDate = new DateTime("2016-12-06")
-        val periodEndDate = new DateTime("2017-02-05")
+        val periodStartDate = new DateTime("2017-12-06")
+        val periodEndDate = new DateTime("2018-02-05")
         val request = validBonusPayment.copy(periodStartDate = periodStartDate, periodEndDate = periodEndDate)
 
         val errors = SUT.validate(request)
@@ -310,8 +328,8 @@ class BonusPaymentValidatorSpec extends PlaySpec
       }
 
       "it is before the periodStartDate" in {
-        val periodStartDate = new DateTime("2017-01-06")
-        val periodEndDate = new DateTime("2016-02-05")
+        val periodStartDate = new DateTime("2017-06-06")
+        val periodEndDate = new DateTime("2017-05-05")
         val request = validBonusPayment.copy(periodStartDate = periodStartDate, periodEndDate = periodEndDate)
 
         val errors = SUT.validate(request)
@@ -320,6 +338,22 @@ class BonusPaymentValidatorSpec extends PlaySpec
           ErrorValidation(
             errorCode = "INVALID_DATE",
             message = "The periodEndDate must be the 5th day of the month which occurs after the periodStartDate",
+            path = Some("/periodEndDate")
+          )
+        )
+      }
+
+      "the supplied date is prior to 6 April 2017" in {
+        val periodStartDate = new DateTime("2017-03-06")
+        val periodEndDate = new DateTime("2017-04-05")
+        val request = validBonusPayment.copy(periodStartDate = periodStartDate, periodEndDate = periodEndDate)
+
+        val errors = SUT.validate(request)
+
+        errors must contain(
+          ErrorValidation(
+            errorCode = "INVALID_DATE",
+            message = "The periodEndDate cannot be before 6 April 2017",
             path = Some("/periodEndDate")
           )
         )


### PR DESCRIPTION
All dates being passed into the API are now validated to ensure they are not before 6 April 2017.

If they are, a 403 Forbidden will be returned with error messages for any dates that fail validation.

The API docs have been updated to ensure the successful examples use dates after 6 April 2017 and additional failure examples have been added which demonstrate the date validation failing.

In addition, some refactoring has been done on some controllers as the methods were extremely long and had duplication which could be abstracted out.