### PR TITLE
Replaced invalid accountIds in API test examples

### DIFF
--- a/resources/public/api/conf/1.0/testdata/bonus-payment-get.md
+++ b/resources/public/api/conf/1.0/testdata/bonus-payment-get.md
@@ -71,7 +71,7 @@
 		    	<p>Request with an invalid accountId</p>
 		    	<p class ="code--block">
 		    		lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>
-		    		accountId: 1234=5678<br>
+		    		accountId: 1234%3D5678<br>
 		    		transactionId: 1234567890
 		    	</p>
 			</td>

--- a/resources/public/api/conf/1.0/testdata/bonus-payment.md
+++ b/resources/public/api/conf/1.0/testdata/bonus-payment.md
@@ -134,7 +134,7 @@
             <td>
               <p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p>
               <p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>
-              accountId: 1234=5678</p>
+              accountId: 1234%3D5678</p>
             </td>
             <td>
                 <p class ="code--block"> {<br>

--- a/resources/public/api/conf/1.0/testdata/close-account.md
+++ b/resources/public/api/conf/1.0/testdata/close-account.md
@@ -74,7 +74,7 @@
                 <p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p>
                 <p class="code--block">
                     lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a>
-                    <br>accountId: 1234=5678
+                    <br>accountId: 1234%3D5678
                 </p>
             </td>
             <td>

--- a/resources/public/api/conf/1.0/testdata/get-account.md
+++ b/resources/public/api/conf/1.0/testdata/get-account.md
@@ -127,7 +127,7 @@
         <p>Request with a valid LISA Manager reference number, but an invalid account ID</p>
         <p class ="code--block">
           lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>
-          accountId: 1234=5678
+          accountId: 1234%3D5678
         </p>
       </td>
       <td></td>

--- a/resources/public/api/conf/1.0/testdata/get-investor-payment.md
+++ b/resources/public/api/conf/1.0/testdata/get-investor-payment.md
@@ -78,7 +78,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid LISA Manager reference number and Transaction ID, but an invalid account ID</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234=5678<br>transactionId: 1234567890</p></td>
+            <td><p>Request with a valid LISA Manager reference number and Transaction ID, but an invalid account ID</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234%3D5678<br>transactionId: 1234567890</p></td>
                         <td></td>
             <td><p>HTTP status: <code class="code--slim">400 (Bad Request)</code></p>
                 <p class ="code--block"> {<br>

--- a/resources/public/api/conf/1.0/testdata/life-event.md
+++ b/resources/public/api/conf/1.0/testdata/life-event.md
@@ -49,7 +49,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234=5678</p></td>
+            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                             "eventType" : "LISA Investor Terminal Ill Health",<br>

--- a/resources/public/api/conf/1.0/testdata/reinstate-account.md
+++ b/resources/public/api/conf/1.0/testdata/reinstate-account.md
@@ -56,7 +56,7 @@
             </td>
             <td>
                 <p class ="code--block"> {<br>
-                                            "accountId": "1234%3D5678"<br>
+                                            "accountId": "1234=5678"<br>
                                         }
                 </p>            
             </td>

--- a/resources/public/api/conf/1.0/testdata/reinstate-account.md
+++ b/resources/public/api/conf/1.0/testdata/reinstate-account.md
@@ -56,7 +56,7 @@
             </td>
             <td>
                 <p class ="code--block"> {<br>
-                                            "accountId": "1234=5678"<br>
+                                            "accountId": "1234%3D5678"<br>
                                         }
                 </p>            
             </td>

--- a/resources/public/api/conf/1.0/testdata/subscription-update.md
+++ b/resources/public/api/conf/1.0/testdata/subscription-update.md
@@ -69,7 +69,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid and account ID</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234=5678</p></td>
+            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid and account ID</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://test-developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing-the-api">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
             <td>
                 <p class ="code--block"> {<br>
                                      	  "firstSubscriptionDate" : "2017-05-20"<br>


### PR DESCRIPTION
Using a raw invalid character returns a 404 error from WSO2. If we URL encode the character - in this case changing '=' to '%3D' - then we get the correct 400 Bad Request error from our service.