### PR TITLE
LISA-1756: Updated subscriptionStatus on GET account

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/models/GetLisaAccountResponse.scala
+++ b/app/uk/gov/hmrc/lisaapi/models/GetLisaAccountResponse.scala
@@ -29,7 +29,7 @@ case class GetLisaAccountSuccessResponse(
   creationReason: String,
   firstSubscriptionDate: DateTime,
   accountStatus: String,
-  subscriptionStatus: Option[String],
+  subscriptionStatus: String,
   accountClosureReason: Option[String],
   closureDate: Option[DateTime],
   transferAccount: Option[GetLisaAccountTransferAccount]
@@ -78,7 +78,7 @@ object GetLisaAccountSuccessResponse {
       },
       firstSubscriptionDate = firstSubscriptionDate,
       accountStatus = status,
-      subscriptionStatus = subscriptionStatus,
+      subscriptionStatus = if (subscriptionStatus.isEmpty) "AVAILABLE" else subscriptionStatus.get,
       accountClosureReason = accountClosureReason.map(cr => cr match {
         case "TRANSFERRED_OUT" => "Transferred out"
         case "ALL_FUNDS_WITHDRAWN" => "All funds withdrawn"
@@ -103,7 +103,7 @@ object GetLisaAccountSuccessResponse {
     (JsPath \ "creationReason").write[String] and
     (JsPath \ "firstSubscriptionDate").write[String].contramap[DateTime](_.toString("yyyy-MM-dd")) and
     (JsPath \ "accountStatus").write[String] and
-    (JsPath \ "subscriptionStatus").writeNullable[String] and
+    (JsPath \ "subscriptionStatus").write[String] and
     (JsPath \ "accountClosureReason").writeNullable[String] and
     (JsPath \ "closureDate").writeNullable[String].contramap[Option[DateTime]](_.map(_.toString("yyyy-MM-dd"))) and
     (JsPath \ "transferAccount").writeNullable[GetLisaAccountTransferAccount]

--- a/resources/public/api/conf/1.0/schemas/LISAAccount.get.schema.json
+++ b/resources/public/api/conf/1.0/schemas/LISAAccount.get.schema.json
@@ -85,15 +85,14 @@
         "transferInDate"
       ]
     }
-  }
-,
-
+  },
   "required": [
     "investorId",
     "accountId",
     "creationReason",
     "firstSubscriptionDate",
-    "accountStatus"
+    "accountStatus",
+    "subscriptionStatus"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/resources/public/api/conf/1.0/testdata/get-account.md
+++ b/resources/public/api/conf/1.0/testdata/get-account.md
@@ -98,6 +98,7 @@
                  "creationReason": "New",<br>
                  "firstSubscriptionDate": "2017-04-06",<br>
                  "accountStatus": "CLOSED",<br>
+                 "subscriptionStatus": "VOID",<br>
                  "accountClosureReason": "All funds withdrawn",<br>
                  "closureDate": "2017-10-25"<br>
              }

--- a/test/unit/connectors/DesConnectorSpec.scala
+++ b/test/unit/connectors/DesConnectorSpec.scala
@@ -1385,7 +1385,54 @@ class DesConnectorSpec extends PlaySpec
             creationReason = "Reinstated",
             firstSubscriptionDate = new DateTime("2016-01-06"),
             accountStatus = "OPEN",
-            subscriptionStatus = Some("AVAILABLE"),
+            subscriptionStatus = "AVAILABLE",
+            accountClosureReason = Some("Transferred out"),
+            closureDate = Some(new DateTime("2016-05-01")),
+            transferAccount = Some(GetLisaAccountTransferAccount(
+              transferredFromAccountId = "123abc789ABC34567890",
+              transferredFromLMRN = "Z123453",
+              transferInDate = new DateTime("2016-03-01")
+            ))
+          )
+        }
+      }
+    }
+
+    "return a subscriptionStatus of AVAILABLE" when {
+      "there is no subscriptionStatus in the json response from DES" in {
+        val responseJson = Json.parse("""{
+                                        |  "investorId": "1234567890",
+                                        |  "status": "OPEN",
+                                        |  "creationDate": "2016-01-01",
+                                        |  "creationReason": "REINSTATED",
+                                        |  "hmrcClosureDate": "2016-02-01",
+                                        |  "accountClosureReason": "TRANSFERRED_OUT",
+                                        |  "transferInDate": "2016-03-01",
+                                        |  "transferOutDate": "2016-04-01",
+                                        |  "xferredFromAccountId": "123abc789ABC34567890",
+                                        |  "xferredFromLmrn": "Z123453",
+                                        |  "lisaManagerClosureDate": "2016-05-01",
+                                        |  "firstSubscriptionDate": "2016-01-06"
+                                        |}""".stripMargin)
+
+        when(mockHttpGet.GET[HttpResponse](any())(any(), any(), any()))
+          .thenReturn(
+            Future.successful(
+              HttpResponse(
+                responseStatus = OK,
+                responseJson = Some(responseJson)
+              )
+            )
+          )
+
+        doRetrieveAccountRequest { response =>
+          response mustBe GetLisaAccountSuccessResponse(
+            accountId = "123456",
+            investorId = "1234567890",
+            creationReason = "Reinstated",
+            firstSubscriptionDate = new DateTime("2016-01-06"),
+            accountStatus = "OPEN",
+            subscriptionStatus = "AVAILABLE",
             accountClosureReason = Some("Transferred out"),
             closureDate = Some(new DateTime("2016-05-01")),
             transferAccount = Some(GetLisaAccountTransferAccount(

--- a/test/unit/controllers/AccountControllerSpec.scala
+++ b/test/unit/controllers/AccountControllerSpec.scala
@@ -718,7 +718,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             creationReason = "New",
             firstSubscriptionDate = new DateTime(validDate),
             accountStatus = "OPEN",
-            subscriptionStatus = None,
+            subscriptionStatus = "AVAILABLE",
             accountClosureReason = None,
             closureDate = None,
             transferAccount = None
@@ -734,7 +734,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
           (json \ "creationReason").as[String] mustBe "New"
           (json \ "firstSubscriptionDate").as[String] mustBe validDate
           (json \ "accountStatus").as[String] mustBe "OPEN"
-          (json \ "subscriptionStatus").asOpt[String] mustBe None
+          (json \ "subscriptionStatus").as[String] mustBe "AVAILABLE"
           (json \ "accountClosureReason").asOpt[String] mustBe None
           (json \ "closureDate").asOpt[String] mustBe None
           (json \ "transferAccount").asOpt[JsObject] mustBe None
@@ -748,7 +748,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             creationReason = "New",
             firstSubscriptionDate = new DateTime(validDate),
             accountStatus = "CLOSED",
-            subscriptionStatus = Some("ACTIVE"),
+            subscriptionStatus = "ACTIVE",
             accountClosureReason = Some("All funds withdrawn"),
             closureDate = Some(new DateTime(validDate)),
             transferAccount = None)
@@ -764,7 +764,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
           (json \ "creationReason").as[String] mustBe "New"
           (json \ "firstSubscriptionDate").as[String] mustBe validDate
           (json \ "accountStatus").as[String] mustBe "CLOSED"
-          (json \ "subscriptionStatus").asOpt[String] mustBe Some("ACTIVE")
+          (json \ "subscriptionStatus").as[String] mustBe "ACTIVE"
           (json \ "accountClosureReason").asOpt[String] mustBe Some("All funds withdrawn")
           (json \ "closureDate").asOpt[String] mustBe Some(validDate)
           (json \ "transferAccount").asOpt[JsObject] mustBe None
@@ -778,7 +778,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             creationReason = "Transferred",
             firstSubscriptionDate = new DateTime(validDate),
             accountStatus = "OPEN",
-            subscriptionStatus = Some("ACTIVE"),
+            subscriptionStatus = "ACTIVE",
             accountClosureReason = None,
             closureDate = None,
             transferAccount = Some(
@@ -801,7 +801,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
           (json \ "creationReason").as[String] mustBe "Transferred"
           (json \ "firstSubscriptionDate").as[String] mustBe validDate
           (json \ "accountStatus").as[String] mustBe "OPEN"
-          (json \ "subscriptionStatus").asOpt[String] mustBe Some("ACTIVE")
+          (json \ "subscriptionStatus").as[String] mustBe "ACTIVE"
           (json \ "accountClosureReason").asOpt[String] mustBe None
           (json \ "closureDate").asOpt[String] mustBe None
           (json \ "transferAccount" \ "transferredFromAccountId").as[String] mustBe "8765432102"
@@ -817,7 +817,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
             creationReason = "New",
             firstSubscriptionDate = new DateTime(validDate),
             accountStatus = "VOID",
-            subscriptionStatus = Some("ACTIVE"),
+            subscriptionStatus = "ACTIVE",
             accountClosureReason = None,
             closureDate = None,
             transferAccount = None
@@ -834,7 +834,7 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
           (json \ "creationReason").as[String] mustBe "New"
           (json \ "firstSubscriptionDate").as[String] mustBe validDate
           (json \ "accountStatus").as[String] mustBe "VOID"
-          (json \ "subscriptionStatus").asOpt[String] mustBe Some("ACTIVE")
+          (json \ "subscriptionStatus").as[String] mustBe "ACTIVE"
           (json \ "accountClosureReason").asOpt[String] mustBe None
           (json \ "closureDate").asOpt[String] mustBe None
           (json \ "transferAccount").asOpt[JsObject] mustBe None
@@ -1140,7 +1140,6 @@ class AccountControllerSpec extends PlaySpec with MockitoSugar with OneAppPerSui
     val res = SUT.getAccountDetails(lisaManager, accountId).apply(FakeRequest(Helpers.GET, "/").withHeaders(acceptHeader))
     callback(res)
   }
-
 
   def doCloseRequest(jsonString: String, lmrn: String = lisaManager, accId: String = accountId)(callback: (Future[Result]) => Unit) {
     val res = SUT.closeLisaAccount(lmrn, accId).apply(FakeRequest(Helpers.PUT, "/").withHeaders(acceptHeader).

--- a/test/unit/services/AccountServiceSpec.scala
+++ b/test/unit/services/AccountServiceSpec.scala
@@ -351,7 +351,7 @@ class AccountServiceSpec extends PlaySpec
     "return a Success Response" when {
 
       "given a success response" in {
-        val successResponse = GetLisaAccountSuccessResponse("123", "456", "All funds withdrawn", new DateTime("201-04-06"), "OPEN", None, None, None, None)
+        val successResponse = GetLisaAccountSuccessResponse("123", "456", "All funds withdrawn", new DateTime("201-04-06"), "OPEN", "AVAILABLE", None, None, None)
 
         when(mockDesConnector.getAccountInformation(any(), any())(any()))
           .thenReturn(Future.successful(successResponse))


### PR DESCRIPTION
* Updated code so if we don't get a subscriptionStatus we return a value of "AVAILABLE"
* Updated API spec so subscriptionStatus is a required field in our response
* Updated test data examples to match changes