### PR TITLE
LISA-1792: Updated discover endpoint example response

### DIFF
--- a/resources/public/api/conf/1.0/examples/LISAManager.get.json
+++ b/resources/public/api/conf/1.0/examples/LISAManager.get.json
@@ -19,6 +19,7 @@
       {"href": "/lifetime-isa/manager/{lisaManagerReferenceNumber}/accounts/{accountId}/transactions", "methods": ["POST"]},
       {"href": "/lifetime-isa/manager/{lisaManagerReferenceNumber}/accounts/{accountId}/transactions/{transactionId}", "methods": ["GET"]}
     ],
-    "bulk payments": {"href": "/lifetime-isa/manager/{lisaManagerReferenceNumber}/payments?startDate={startDate}&endDate={endDate}", "methods": ["GET"]}
+    "bulk payments": {"href": "/lifetime-isa/manager/{lisaManagerReferenceNumber}/payments?startDate={startDate}&endDate={endDate}", "methods": ["GET"]},
+    "bulk payment breakdown": {"href": "/lifetime-isa/manager/$lisaManagerReferenceNumber/accounts/{accountId}/transactions/{transactionId}/payments", "methods": ["GET"]}
   }
 }


### PR DESCRIPTION
It was missing the bulk payment breakdown, which was already being returned
from the Controller.