### PR TITLE
Log when a 201 response isn't parsed correctly

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
@@ -299,7 +299,7 @@ trait DesConnector extends ServicesConfig {
       case Success(data) =>
         (res.status, data)
       case Failure(er) =>
-        if (res.status == 200) {
+        if (res.status == 200 | res.status == 201) {
           Logger.error(s"Error from DES (parsing as DesResponse): ${er.getMessage}")
         }
 


### PR DESCRIPTION
In addition to the existing logging for a 200 response not being parsed correctly.