### PR TITLE
LISA-1934: Removed unneccesary decimal places from GET bonus request examples

### DIFF
--- a/resources/public/api/conf/1.0/examples/LISATransaction.get.response.1.json
+++ b/resources/public/api/conf/1.0/examples/LISATransaction.get.response.1.json
@@ -2,15 +2,15 @@
   "periodStartDate": "2017-04-06",
   "periodEndDate": "2017-05-05",
   "inboundPayments": {
-    "newSubsForPeriod": 4000.00,
-    "newSubsYTD": 4000.00,
-    "totalSubsForPeriod": 40000.00,
-    "totalSubsYTD": 40000.00
+    "newSubsForPeriod": 4000,
+    "newSubsYTD": 4000,
+    "totalSubsForPeriod": 40000,
+    "totalSubsYTD": 40000
   },
   "bonuses": {
-    "bonusPaidYTD": 0.0,
-    "bonusDueForPeriod": 10000.00,
-    "totalBonusDueYTD": 10000.00,
+    "bonusPaidYTD": 0,
+    "bonusDueForPeriod": 10000,
+    "totalBonusDueYTD": 10000,
     "claimReason": "Regular Bonus"
   }
 }

--- a/resources/public/api/conf/1.0/examples/LISATransaction.get.response.json
+++ b/resources/public/api/conf/1.0/examples/LISATransaction.get.response.json
@@ -3,18 +3,18 @@
   "periodStartDate": "2017-04-06",
   "periodEndDate": "2017-05-05",
   "htbTransfer": {
-    "htbTransferInForPeriod": 0.00,
-    "htbTransferTotalYTD": 0.00
+    "htbTransferInForPeriod": 0,
+    "htbTransferTotalYTD": 0
   },
   "inboundPayments": {
-    "newSubsForPeriod": 4000.00,
-    "newSubsYTD": 4000.00,
-    "totalSubsForPeriod": 4000.00,
-    "totalSubsYTD": 4000.00
+    "newSubsForPeriod": 4000,
+    "newSubsYTD": 4000,
+    "totalSubsForPeriod": 4000,
+    "totalSubsYTD": 4000
   },
   "bonuses": {
-    "bonusDueForPeriod": 1000.00,
-    "totalBonusDueYTD": 1000.00,
+    "bonusDueForPeriod": 1000,
+    "totalBonusDueYTD": 1000,
     "claimReason": "Life Event"
   }
 }

--- a/resources/public/api/conf/1.0/testdata/bonus-payment-get.md
+++ b/resources/public/api/conf/1.0/testdata/bonus-payment-get.md
@@ -27,19 +27,19 @@
   "periodStartDate": "2017-04-06",
   "periodEndDate": "2017-05-05",
   "htbTransfer": {
-    "htbTransferInForPeriod": 0.00,
-    "htbTransferTotalYTD": 0.00
+    "htbTransferInForPeriod": 0,
+    "htbTransferTotalYTD": 0
   },
   "inboundPayments": {
-    "newSubsForPeriod": 4000.00,
-    "newSubsYTD": 4000.00,
-    "totalSubsForPeriod": 40000.00,
-    "totalSubsYTD": 40000.00
+    "newSubsForPeriod": 4000,
+    "newSubsYTD": 4000,
+    "totalSubsForPeriod": 40000,
+    "totalSubsYTD": 40000
   },
   "bonuses": {
-    "bonusPaidYTD": 0.0,
-    "bonusDueForPeriod": 10000.00,
-    "totalBonusDueYTD": 10000.00,
+    "bonusPaidYTD": 0,
+    "bonusDueForPeriod": 10000,
+    "totalBonusDueYTD": 10000,
     "claimReason": "Life Event"
   }
 }
@@ -62,15 +62,15 @@
   "periodStartDate": "2017-04-06",
   "periodEndDate": "2017-05-05",
   "inboundPayments": {
-    "newSubsForPeriod": 4000.00,
-    "newSubsYTD": 4000.00,
-    "totalSubsForPeriod": 40000.00,
-    "totalSubsYTD": 40000.00
+    "newSubsForPeriod": 4000,
+    "newSubsYTD": 4000,
+    "totalSubsForPeriod": 40000,
+    "totalSubsYTD": 40000
   },
   "bonuses": {
-    "bonusPaidYTD": 0.0,
-    "bonusDueForPeriod": 10000.00,
-    "totalBonusDueYTD": 10000.00,
+    "bonusPaidYTD": 0,
+    "bonusDueForPeriod": 10000,
+    "totalBonusDueYTD": 10000,
     "claimReason": "Regular Bonus"
   }
 }


### PR DESCRIPTION
The API's GET response only returns decimals where they are needed, so the documentation has now been updated to reflect this

For example the API would not return 1000.00 it would return 1000, similarly it would return 1000.5 instead of 1000.50

Only if there are two non-zero decimals would two decimal places be returned. i.e. 1000.99 would be returned as 1000.99