### PR TITLE
Updated annual return API specification

### DIFF
--- a/resources/public/api/conf/2.0/examples/AnnualReturn.post.json
+++ b/resources/public/api/conf/2.0/examples/AnnualReturn.post.json
@@ -1,6 +1,6 @@
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,

--- a/resources/public/api/conf/2.0/examples/AnnualReturnSuperseded.post.json
+++ b/resources/public/api/conf/2.0/examples/AnnualReturnSuperseded.post.json
@@ -1,6 +1,6 @@
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 65,

--- a/resources/public/api/conf/2.0/schemas/AnnualReturn.post.schema.json
+++ b/resources/public/api/conf/2.0/schemas/AnnualReturn.post.schema.json
@@ -8,9 +8,10 @@
     },
     "lisaManagerName": {
       "type": "string",
-      "description": "The name of the LISA manager.",
+      "description": "The name of the LISA provider.",
       "maxLength": 50,
-      "pattern": "^[a-zA-Z0-9 '/,&().-]{1,50}$"
+      "pattern": "^[a-zA-Z0-9 '/,&().-]{1,50}$",
+      "example": "Company Name"
     },
     "taxYear": {
       "type": "integer",

--- a/resources/public/api/conf/2.0/testdata/annual-return.md
+++ b/resources/public/api/conf/2.0/testdata/annual-return.md
@@ -16,7 +16,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -44,7 +44,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 65,
@@ -76,7 +76,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -100,7 +100,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -169,7 +169,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -205,7 +205,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2016,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -236,7 +236,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 3000,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -267,7 +267,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -291,7 +291,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -322,7 +322,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 65,
@@ -350,7 +350,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -374,7 +374,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,
@@ -405,7 +405,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 65,
@@ -433,7 +433,7 @@
 <pre class="code--block">
 {
   "eventDate": "2018-04-05",
-  "lisaManagerName": "LISA Manager",
+  "lisaManagerName": "Company Name",
   "taxYear": 2018,
   "marketValueCash": 0,
   "marketValueStocksAndShares": 55,


### PR DESCRIPTION
Added additional clarity on what is required for the lisaManagerName field.

Our User Research had identified this as a sticking point. It wasn't clear enough whether the user should provide the LISA provider's name (i.e. the company name), or the name of the individual responsible for managing that account.