### PR TITLE
Replaced the URL for every "use your test user profile" link.

### DIFF
--- a/resources/public/api/conf/1.0/testdata/bonus-payment-get.md
+++ b/resources/public/api/conf/1.0/testdata/bonus-payment-get.md
@@ -14,7 +14,7 @@
 		    <td>
 		    	<p>Retrieve details for a bonus payment associated with a LISA account</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567890<br>
 		    		<strong>transactionId:</strong> 0123456789
 		    	</p>
@@ -50,7 +50,7 @@
 	    <td>
 		    	<p>Retrieve details for a bonus payment associated with a LISA account (regular bonus)</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567890<br>
 		    		<strong>transactionId:</strong> 0003456789
 		    	</p>
@@ -100,7 +100,7 @@
 		    <td>
 		    	<p>Request with an invalid accountId</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234%3D5678<br>
 		    		<strong>transactionId:</strong> 0123456789
 		    	</p>
@@ -119,7 +119,7 @@
 		    <td>
 		    	<p>Request with an invalid bonus payment transaction</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567890<br>
 		    		<strong>transactionId:</strong> 0000000404
 		    	</p>
@@ -138,7 +138,7 @@
 		    <td>
 		    	<p>Request with an invalid LISA account</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567899<br>
 		    		<strong>transactionId:</strong> 1000000404
 		    	</p>

--- a/resources/public/api/conf/1.0/testdata/bonus-payment.md
+++ b/resources/public/api/conf/1.0/testdata/bonus-payment.md
@@ -15,7 +15,7 @@
               <p>Request with a valid payload, LISA Manager reference number and account ID</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -64,7 +64,7 @@
               <p>Request with a valid payload, LISA Manager reference number and account ID (late notification)</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567891
@@ -109,7 +109,7 @@
               <p>Request with a valid payload, LISA Manager reference number and account ID (regular bonus)</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -198,7 +198,7 @@
               <p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p>
               <p class ="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234%3D5678
@@ -243,7 +243,7 @@
             <p>Request containing invalid and/or missing data</p>
             <p class="code--block">
               <strong>lisaManagerReferenceNumber:</strong><br>
-              <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+              <a href="#testing">Use your test user profile</a><br>
               <br>
               <strong>accountId:</strong><br>
               1234567890
@@ -314,7 +314,7 @@
               <p>Request with invalid monetary amounts and/or invalid dates</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -406,7 +406,7 @@
             <p>Request with a 'claimReason' of 'Life Event', but without a lifeEventId</p>
             <p class="code--block">
               <strong>lisaManagerReferenceNumber:</strong><br>
-              <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+              <a href="#testing">Use your test user profile</a><br>
               <br>
               <strong>accountId:</strong><br>
               1234567890
@@ -450,7 +450,7 @@
               <p>Request containing invalid bonus payment figures</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 0000000403
@@ -491,7 +491,7 @@
               <p>Request for an account that has already been closed or made void.</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 0000000903
@@ -532,7 +532,7 @@
               <p>Request for a bonus claim after 5 April 2018 containing help to buy funds.</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -576,7 +576,7 @@
               <p>Request containing a life event ID that does not exist</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1000000404
@@ -621,7 +621,7 @@
               <p>Request containing an account ID that does not exist</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 0000000404
@@ -666,7 +666,7 @@
               <p>Request with an invalid 'Accept' header</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890<br>

--- a/resources/public/api/conf/1.0/testdata/close-account.md
+++ b/resources/public/api/conf/1.0/testdata/close-account.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -34,7 +34,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -79,7 +79,7 @@
             <td>
                 <p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>accountId: 1234%3D5678
                 </p>
             </td>
@@ -101,7 +101,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -131,7 +131,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a closure date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing a closure date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -157,7 +157,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been voided</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234560</p></td>
+            <td><p>Request for an account that has already been voided</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234560</p></td>
             <td>
 <pre class="code--block">
 {
@@ -176,7 +176,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been closed</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234561</p></td>
+            <td><p>Request for an account that has already been closed</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234561</p></td>
             <td>
 <pre class="code--block">
 {
@@ -195,7 +195,7 @@
             </td>
         </tr>
          <tr>
-            <td><p>Request to close an account with cancellation as the reason when the cancellation period is over</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234568</p></td>
+            <td><p>Request to close an account with cancellation as the reason when the cancellation period is over</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234568</p></td>
             <td>
 <pre class="code--block">
 {
@@ -215,7 +215,7 @@
         </tr>
         </tr>
          <tr>
-            <td><p>Request to close an account with all funds withdrawn as the reason and it is still within the cancellation period</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234569</p></td>
+            <td><p>Request to close an account with all funds withdrawn as the reason and it is still within the cancellation period</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234569</p></td>
             <td>
 <pre class="code--block">
 {
@@ -234,7 +234,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234562</p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234562</p></td>
             <td>
 <pre class="code--block">
 {
@@ -253,7 +253,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/1.0/testdata/create-account.md
+++ b/resources/public/api/conf/1.0/testdata/create-account.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Create request with a valid payload and LISA Manager reference number</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Create request with a valid payload and LISA Manager reference number</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -36,7 +36,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Transfer request with a valid payload and LISA Manager reference number</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Transfer request with a valid payload and LISA Manager reference number</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -87,7 +87,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -124,7 +124,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing dates before 6 April 2017</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing dates before 6 April 2017</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -162,7 +162,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing investor details which cannot be found</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing investor details which cannot be found</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -183,7 +183,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an investor who is not eligible for a LISA account</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing an investor who is not eligible for a LISA account</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -204,7 +204,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an investor who has not passed the compliance check</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing an investor who has not passed the compliance check</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -225,7 +225,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Transfer request containing transfer details which cannot be found in HMRC's records</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Transfer request containing transfer details which cannot be found in HMRC's records</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -251,7 +251,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Transfer request without transfer details</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Transfer request without transfer details</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -272,7 +272,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Create request containing transfer details</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Create request containing transfer details</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -298,7 +298,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a LISA account which has already been closed</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing a LISA account which has already been closed</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -319,7 +319,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a LISA account which has already been voided</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing a LISA account which has already been voided</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -340,7 +340,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
 <pre class="code--block">
 {
@@ -361,7 +361,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a pre-existing account</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for a pre-existing account</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/1.0/testdata/get-account.md
+++ b/resources/public/api/conf/1.0/testdata/get-account.md
@@ -12,7 +12,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number and account ID (open account)</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 1234567890
         </p>
       </td>
@@ -34,7 +34,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number and account ID (transferred account)</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 1234567891
         </p>
       </td>
@@ -61,7 +61,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number and account ID (voided account)</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 1000000200
         </p>
       </td>
@@ -83,7 +83,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number and account ID (closed account)</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 2000000200
         </p>
       </td>
@@ -125,7 +125,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number, but an invalid account ID</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 1234%3D5678
         </p>
       </td>
@@ -143,7 +143,7 @@
         <td>
             <p>Request containing an account ID that does not exist</p>
             <p class="code--block">
-                lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                 accountId: 0000000404
             </p>
         </td>
@@ -161,7 +161,7 @@
       <td>
         <p>Request with an invalid 'Accept' header</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
           <br>accountId: 1234567890<br>
           <br>
           Accept: application/vnd.hmrc.1.0

--- a/resources/public/api/conf/1.0/testdata/get-bulk-payment.md
+++ b/resources/public/api/conf/1.0/testdata/get-bulk-payment.md
@@ -12,7 +12,7 @@
             <td>
                 <p>Request for payments where some are found</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-05-20<br>
                     endDate: 2017-10-20
                 </p>
@@ -49,7 +49,7 @@
             <td>
                 <p>Request for payments where none are found</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-04-06<br>
                     endDate: 2017-04-06
                 </p>
@@ -83,7 +83,7 @@
             <td>
                 <p>Request with startDate in the wrong format</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 20-05-2017<br>
                     endDate: 2017-05-20
                 </p>
@@ -101,7 +101,7 @@
             <td>
                 <p>Request with endDate in the wrong format</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-05-20<br>
                     endDate: 20-05-2017
                 </p>
@@ -119,7 +119,7 @@
             <td>
                 <p>Request with startDate and endDate in the wrong format</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 20-05-2017<br>
                     endDate: 20-05-2017
                 </p>
@@ -137,7 +137,7 @@
             <td>
                 <p>Request with and endDate in the future</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: (today's date)<br>
                     endDate: (any date in the future)
                 </p>
@@ -155,7 +155,7 @@
             <td>
                 <p>Request with an endDate before the startDate</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-12-20<br>
                     endDate: 2017-12-19
                 </p>
@@ -173,7 +173,7 @@
             <td>
                 <p>Request with an endDate before the startDate</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-04-05<br>
                     endDate: 2017-04-06
                 </p>
@@ -191,7 +191,7 @@
             <td>
                 <p>Request with an endDate over a year after startDate</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-04-06<br>
                     endDate: 2018-04-07
                 </p>
@@ -209,7 +209,7 @@
             <td>
                 <p>Request with an invalid 'Accept' header</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-04-06<br>
                     endDate: 2017-05-05
                     <br>

--- a/resources/public/api/conf/1.0/testdata/get-investor-payment.md
+++ b/resources/public/api/conf/1.0/testdata/get-investor-payment.md
@@ -9,7 +9,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request for a paid transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0123456789</p></td>
+            <td><p>Request for a paid transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0123456789</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -24,7 +24,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a pending transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0000000200</p></td>
+            <td><p>Request for a pending transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0000000200</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -36,7 +36,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a pending payment with a due date</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 3000000200</p></td>
+            <td><p>Request for a pending payment with a due date</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 3000000200</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -49,7 +49,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a cancelled transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 1000000200</p></td>
+            <td><p>Request for a cancelled transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 1000000200</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -61,7 +61,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a void transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2000000200</p></td>
+            <td><p>Request for a void transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2000000200</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -84,7 +84,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid LISA Manager reference number and Transaction ID, but an invalid account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234%3D5678<br>transactionId: 0123456789</p></td>
+            <td><p>Request with a valid LISA Manager reference number and Transaction ID, but an invalid account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234%3D5678<br>transactionId: 0123456789</p></td>
             <td><p>HTTP status: <code class="code--slim">400 (Bad Request)</code></p>
 <pre class="code--block">
 {
@@ -95,7 +95,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a transaction that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0000000404</p></td>
+            <td><p>Request for a transaction that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0000000404</p></td>
             <td><p>HTTP status: <code class="code--slim">404 (Not Found)</code></p>
 <pre class="code--block">
 {
@@ -106,7 +106,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567899<br>transactionId: 1000000404</p></td>
+            <td><p>Request for an account that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567899<br>transactionId: 1000000404</p></td>
             <td><p>HTTP status: <code class="code--slim">404 (Not Found)</code></p>
 <pre class="code--block">
 {
@@ -117,7 +117,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0123456789<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0123456789<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td><p>HTTP status: <code class="code--slim">406 (Not Acceptable)</code></p>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/1.0/testdata/life-event.md
+++ b/resources/public/api/conf/1.0/testdata/life-event.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -53,7 +53,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
+            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
             <td>
 <pre class="code--block">
 {
@@ -72,7 +72,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -102,7 +102,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an event date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing an event date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -128,7 +128,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a life event that conflicts with a previously reported event</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000403</p></td>
+            <td><p>Request containing a life event that conflicts with a previously reported event</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000403</p></td>
             <td>
 <pre class="code--block">
 {
@@ -147,7 +147,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been closed or voided</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000903</p></td>
+            <td><p>Request for an account that has already been closed or voided</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000903</p></td>
             <td>
 <pre class="code--block">
 {
@@ -166,7 +166,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
             <td>
 <pre class="code--block">
 {
@@ -185,7 +185,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
 <pre class="code--block">
 {
@@ -204,7 +204,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an already reported event</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000409</p></td>
+            <td><p>Request containing an already reported event</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000409</p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/1.0/testdata/lisa-create-investor.md
+++ b/resources/public/api/conf/1.0/testdata/lisa-create-investor.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload and LISA Manager reference number</p> <p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request with a valid payload and LISA Manager reference number</p> <p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -57,7 +57,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -99,7 +99,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing investor details which do not match HMRC’s records</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing investor details which do not match HMRC’s records</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -120,7 +120,7 @@
              </td>
         </tr>
         <tr>
-           <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br><br>Accept: application/vnd.hmrc.1.0</p></td>
+           <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br><br>Accept: application/vnd.hmrc.1.0</p></td>
            <td>
 <pre class="code--block">
 {
@@ -141,7 +141,7 @@
            </td>
         </tr>
         <tr>
-            <td><p>Request containing a pre-existing investor’s details</p> <p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing a pre-existing investor’s details</p> <p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/1.0/testdata/reinstate-account.md
+++ b/resources/public/api/conf/1.0/testdata/reinstate-account.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -55,7 +55,7 @@
             <td>
                 <p>Request with a invalid payload</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                 </p>
             </td>
             <td>
@@ -82,7 +82,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that is open or active</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for an account that is open or active</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -100,7 +100,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that is closed with a closure reason as transferred out</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for an account that is closed with a closure reason as transferred out</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -118,7 +118,7 @@
             </td>
         </tr>
          <tr>
-            <td><p>Request for an account that is closed with a closure reason as cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for an account that is closed with a closure reason as cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -136,7 +136,7 @@
             </td>
         </tr>
          <tr>
-            <td><p>Request for an account that is closed with a closure reason as cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for an account that is closed with a closure reason as cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -154,7 +154,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/1.0/testdata/subscription-update.md
+++ b/resources/public/api/conf/1.0/testdata/subscription-update.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -34,7 +34,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567891</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567891</p></td>
             <td>
 <pre class="code--block">
 {
@@ -75,7 +75,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
+            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
             <td>
 <pre class="code--block">
 {
@@ -93,7 +93,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -118,7 +118,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a first subscription date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing a first subscription date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -143,7 +143,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been closed</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000901</p></td>
+            <td><p>Request for an account that has already been closed</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000901</p></td>
             <td>
 <pre class="code--block">
 {
@@ -161,7 +161,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been void</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000902</p></td>
+            <td><p>Request for an account that has already been void</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000902</p></td>
             <td>
 <pre class="code--block">
 {
@@ -179,7 +179,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
             <td>
 <pre class="code--block">
 {
@@ -197,7 +197,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/annual-return.md
+++ b/resources/public/api/conf/2.0/testdata/annual-return.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Successfully sent an annual return of information</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Successfully sent an annual return of information</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -39,7 +39,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Successfully corrected an annual return of information</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Successfully corrected an annual return of information</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -95,7 +95,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Account ID in the wrong format</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
+            <td><p>Account ID in the wrong format</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
             <td>
 <pre class="code--block">
 {
@@ -119,7 +119,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Wrong or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Wrong or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -164,7 +164,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>A mixture of cash and stocks and shares in the same annual return</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>A mixture of cash and stocks and shares in the same annual return</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -200,7 +200,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Tax year before 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Tax year before 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -231,7 +231,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Tax year in the future</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Tax year in the future</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -262,7 +262,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Account cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 2000000403</p></td>
+            <td><p>Account cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 2000000403</p></td>
             <td>
 <pre class="code--block">
 {
@@ -286,7 +286,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Account void</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 3000000403</p></td>
+            <td><p>Account void</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 3000000403</p></td>
             <td>
 <pre class="code--block">
 {
@@ -313,7 +313,7 @@
             <td>
                 <p>Supersede details do not match the original return of information</p>
                 <p class="code--block">
-                lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                 <br>
                 accountId: 5000000403
                 </p>
@@ -345,7 +345,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Account could not be found</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
+            <td><p>Account could not be found</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
             <td>
 <pre class="code--block">
 {
@@ -369,7 +369,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Accept header is missing or invalid</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Accept header is missing or invalid</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
 <pre class="code--block">
 {
@@ -396,7 +396,7 @@
             <td>
                 <p>Life event already superseded</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1000000409
                 </p>
@@ -428,7 +428,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Life event already exists</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000409</p></td>
+            <td><p>Life event already exists</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000409</p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/bonus-payment-get.md
+++ b/resources/public/api/conf/2.0/testdata/bonus-payment-get.md
@@ -14,7 +14,7 @@
 		    <td>
 		    	<p>Retrieve details for a bonus payment associated with a LISA account</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567890<br>
 		    		<strong>transactionId:</strong> 0123456789
 		    	</p>
@@ -51,7 +51,7 @@
 	    <td>
 		    	<p>Retrieve details for a bonus payment associated with a LISA account (regular bonus)</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567890<br>
 		    		<strong>transactionId:</strong> 0003456789
 		    	</p>
@@ -83,7 +83,7 @@
 	    <td>
 		    	<p>Retrieve a superseded transaction (bonus recovery)</p>
 		    	<p class="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567890<br>
 		    		<strong>transactionId:</strong> 0000456789
 		    	</p>
@@ -121,7 +121,7 @@
 	    <td>
 		    	<p>Retrieve a superseded transaction (additional bonus)</p>
 		    	<p class="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567890<br>
 		    		<strong>transactionId:</strong> 0000056789
 		    	</p>
@@ -177,7 +177,7 @@
 		    <td>
 		    	<p>Request with an invalid accountId</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234%3D5678<br>
 		    		<strong>transactionId:</strong> 0123456789
 		    	</p>
@@ -196,7 +196,7 @@
 		    <td>
 		    	<p>Request with an invalid bonus payment transaction</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567890<br>
 		    		<strong>transactionId:</strong> 0000000404
 		    	</p>
@@ -215,7 +215,7 @@
 		    <td>
 		    	<p>Request with an invalid LISA account</p>
 		    	<p class ="code--block">
-		    		<strong>lisaManagerReferenceNumber:</strong> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+		    		<strong>lisaManagerReferenceNumber:</strong> <a href="#testing">Use your test user profile</a><br>
 		    		<strong>accountId:</strong> 1234567899<br>
 		    		<strong>transactionId:</strong> 1000000404
 		    	</p>

--- a/resources/public/api/conf/2.0/testdata/bonus-payment.md
+++ b/resources/public/api/conf/2.0/testdata/bonus-payment.md
@@ -15,7 +15,7 @@
               <p>Request with a valid payload, LISA Manager reference number and account ID</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -64,7 +64,7 @@
               <p>Request with a valid payload, LISA Manager reference number and account ID (late notification)</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567891
@@ -109,7 +109,7 @@
               <p>Request with a valid payload, LISA Manager reference number and account ID (regular bonus)</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -153,7 +153,7 @@
               <p>Superseded transaction - Bonus recovery</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -204,7 +204,7 @@
               <p>Superseded transaction - Additional bonus</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -299,7 +299,7 @@
               <p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p>
               <p class ="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234%3D5678
@@ -344,7 +344,7 @@
             <p>Request containing invalid and/or missing data</p>
             <p class="code--block">
               <strong>lisaManagerReferenceNumber:</strong><br>
-              <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+              <a href="#testing">Use your test user profile</a><br>
               <br>
               <strong>accountId:</strong><br>
               1234567890
@@ -441,7 +441,7 @@
               <p>Request with invalid monetary amounts and/or invalid dates</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -533,7 +533,7 @@
             <p>Request with a 'claimReason' of 'Life Event', but without a lifeEventId</p>
             <p class="code--block">
               <strong>lisaManagerReferenceNumber:</strong><br>
-              <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+              <a href="#testing">Use your test user profile</a><br>
               <br>
               <strong>accountId:</strong><br>
               1234567890
@@ -577,7 +577,7 @@
               <p>Request containing invalid bonus payment figures</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 0000000403
@@ -622,7 +622,7 @@
               <p>Request for an account that has already been closed</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1000000903
@@ -667,7 +667,7 @@
              <p>Request for an account that has already been voided</p>
              <p class="code--block">
                <strong>lisaManagerReferenceNumber:</strong><br>
-               <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+               <a href="#testing">Use your test user profile</a><br>
                <br>
                <strong>accountId:</strong><br>
                2000000903
@@ -713,7 +713,7 @@
              <p>Request for an account that has already been cancelled</p>
              <p class="code--block">
                <strong>lisaManagerReferenceNumber:</strong><br>
-               <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+               <a href="#testing">Use your test user profile</a><br>
                <br>
                <strong>accountId:</strong><br>
                3000000903
@@ -758,7 +758,7 @@
               <p>Request for a bonus claim after 5 April 2018 containing help to buy funds.</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890
@@ -802,7 +802,7 @@
               <p>Superseded transaction containing details which don't match an existing transaction</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1000000403
@@ -849,7 +849,7 @@
               <p>Superseded transaction with an outcome error</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 2000000403
@@ -896,7 +896,7 @@
               <p>A bonus claim for an account with no subscriptions in the given tax year</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 3000000403
@@ -943,7 +943,7 @@
               <p>Request containing a life event ID that does not exist</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1000000404
@@ -988,7 +988,7 @@
               <p>Request containing an account ID that does not exist</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 0000000404
@@ -1033,7 +1033,7 @@
               <p>Request for a bonus claim that has already been requested</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 0000000409
@@ -1079,7 +1079,7 @@
               <p>Request to supersede a transaction that has already been superseded</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1000000409
@@ -1127,7 +1127,7 @@
               <p>Request with an invalid 'Accept' header</p>
               <p class="code--block">
                 <strong>lisaManagerReferenceNumber:</strong><br>
-                <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                <a href="#testing">Use your test user profile</a><br>
                 <br>
                 <strong>accountId:</strong><br>
                 1234567890<br>

--- a/resources/public/api/conf/2.0/testdata/close-account.md
+++ b/resources/public/api/conf/2.0/testdata/close-account.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -34,7 +34,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -79,7 +79,7 @@
             <td>
                 <p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>accountId: 1234%3D5678
                 </p>
             </td>
@@ -101,7 +101,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -131,7 +131,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a closure date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing a closure date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -157,7 +157,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been voided</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234560</p></td>
+            <td><p>Request for an account that has already been voided</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234560</p></td>
             <td>
 <pre class="code--block">
 {
@@ -176,7 +176,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been closed</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234561</p></td>
+            <td><p>Request for an account that has already been closed</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234561</p></td>
             <td>
 <pre class="code--block">
 {
@@ -195,7 +195,7 @@
             </td>
         </tr>
          <tr>
-            <td><p>Request to close an account with cancellation as the reason when the cancellation period is over</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234568</p></td>
+            <td><p>Request to close an account with cancellation as the reason when the cancellation period is over</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234568</p></td>
             <td>
 <pre class="code--block">
 {
@@ -215,7 +215,7 @@
         </tr>
         </tr>
          <tr>
-            <td><p>Request to close an account with all funds withdrawn as the reason and it is still within the cancellation period</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234569</p></td>
+            <td><p>Request to close an account with all funds withdrawn as the reason and it is still within the cancellation period</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234569</p></td>
             <td>
 <pre class="code--block">
 {
@@ -234,7 +234,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: A1234562</p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: A1234562</p></td>
             <td>
 <pre class="code--block">
 {
@@ -253,7 +253,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/create-account.md
+++ b/resources/public/api/conf/2.0/testdata/create-account.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Create request with a valid payload and LISA Manager reference number</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Create request with a valid payload and LISA Manager reference number</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -36,7 +36,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Transfer request with a valid payload and LISA Manager reference number</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Transfer request with a valid payload and LISA Manager reference number</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -87,7 +87,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -124,7 +124,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing dates before 6 April 2017</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing dates before 6 April 2017</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -162,7 +162,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing investor details which cannot be found</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing investor details which cannot be found</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -183,7 +183,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an investor who is not eligible for a LISA account</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing an investor who is not eligible for a LISA account</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -204,7 +204,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an investor who has not passed the compliance check</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing an investor who has not passed the compliance check</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -225,7 +225,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Transfer request containing transfer details which cannot be found in HMRC's records</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Transfer request containing transfer details which cannot be found in HMRC's records</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -251,7 +251,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Transfer request without transfer details</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Transfer request without transfer details</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -272,7 +272,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Create request containing transfer details</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Create request containing transfer details</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -298,7 +298,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a LISA account which has already been closed</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing a LISA account which has already been closed</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -319,7 +319,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a LISA account which has already been voided</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing a LISA account which has already been voided</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -340,7 +340,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
 <pre class="code--block">
 {
@@ -361,7 +361,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a pre-existing account</p><p class ="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for a pre-existing account</p><p class ="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/fund-release-extension.md
+++ b/resources/public/api/conf/2.0/testdata/fund-release-extension.md
@@ -14,7 +14,7 @@
             <td>
                 <p>First purchase extension</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1234567890
                 </p>
@@ -45,7 +45,7 @@
             <td>
                 <p>Superseded first purchase extension</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1234567890
                 </p>
@@ -79,7 +79,7 @@
             <td>
                 <p>Second purchase extension</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1234567890
                 </p>
@@ -110,7 +110,7 @@
             <td>
                 <p>Superseded second purchase extension</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1234567890
                 </p>
@@ -171,7 +171,7 @@
             <td>
                 <p>Request with a valid payload and an invalid account ID</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1234%3D5678
                 </p>
@@ -198,7 +198,7 @@
             <td>
                 <p>Request containing invalid and/or missing data</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1234567890
                 </p>
@@ -241,7 +241,7 @@
             <td>
                 <p>The LISA account is already closed</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1000000403
                 </p>
@@ -268,7 +268,7 @@
             <td>
                 <p>The LISA account is already cancelled</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 2000000403
                 </p>
@@ -295,7 +295,7 @@
             <td>
                 <p>The LISA account is already void</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 3000000403
                 </p>
@@ -322,7 +322,7 @@
             <td>
                 <p>A first extension has not yet been approved</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 7000000403
                 </p>
@@ -349,7 +349,7 @@
             <td>
                 <p>First extension already approved</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 8000000403
                 </p>
@@ -376,7 +376,7 @@
             <td>
                 <p>Second extension already approved</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 9000000403
                 </p>
@@ -403,7 +403,7 @@
             <td>
                 <p>Supersede details do not match the original request</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 5000000403
                 </p>
@@ -433,7 +433,7 @@
             <td>
                 <p>Account not found</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 0000000404
                 </p>
@@ -460,7 +460,7 @@
             <td>
                 <p>Fund release not found</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1000000404
                 </p>
@@ -487,7 +487,7 @@
             <td>
                 <p>Extension already exists</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 0000000409
                 </p>
@@ -514,7 +514,7 @@
             <td>
                 <p>The associated fund release has been superseded</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 2000000409
                 </p>
@@ -541,7 +541,7 @@
             <td>
                 <p>The extension you are superseding has already been superseded</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                     <br>
                     accountId: 1000000409
                 </p>

--- a/resources/public/api/conf/2.0/testdata/fund-release-outcome.md
+++ b/resources/public/api/conf/2.0/testdata/fund-release-outcome.md
@@ -13,7 +13,7 @@
     <tr>
       <td>
         <p>Purchase outcome created</p>
-        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1234567890 </p>
+        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1234567890 </p>
       </td>
       <td>
         <pre class="code--block">
@@ -42,7 +42,7 @@
     <tr>
       <td>
         <p>Purchase outcome superseded</p>
-        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1234567890 </p>
+        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1234567890 </p>
       </td>
       <td>
         <pre class="code--block">
@@ -100,7 +100,7 @@
     <tr>
       <td>
         <p>Invalid Account ID</p>
-        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1234%3D5678 </p>
+        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1234%3D5678 </p>
       </td>
       <td>
         <pre class="code--block">
@@ -125,7 +125,7 @@
     <tr>
       <td>
         <p>Supersede details do not match the original request</p>
-        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />5000000403 </p>
+        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />5000000403 </p>
       </td>
       <td>
         <pre class="code--block">
@@ -154,7 +154,7 @@
     <tr>
       <td>
         <p>Fund release not found</p>
-        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1000000404 </p>
+        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1000000404 </p>
       </td>
       <td>
         <pre class="code--block">
@@ -179,7 +179,7 @@
     <tr>
       <td>
         <p>Investor account not found</p>
-        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />0000000404 </p>
+        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />0000000404 </p>
       </td>
       <td>
         <pre class="code--block"> 
@@ -204,7 +204,7 @@
     <tr>
       <td>
         <p>The purchase outcome you are superseding has already been superseded</p>
-        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1000000409 </p>
+        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />1000000409 </p>
       </td>
       <td>
         <pre class="code--block">
@@ -233,7 +233,7 @@
     <tr>
       <td>
         <p>Purchase outcome already exists</p>
-        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />0000000409 </p>
+        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />0000000409 </p>
       </td>
       <td>
         <pre class="code--block">
@@ -258,7 +258,7 @@
     <tr>
       <td>
         <p>The associated fund release has been superseded</p>
-        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />2000000409 </p>
+        <p class="code--block"> <strong>lisaManagerReferenceNumber:</strong><br /> <a href="#testing">Use your test user profile</a><br /> <br /> <strong>accountId:</strong><br />2000000409 </p>
       </td>
       <td>
         <pre class="code--block">

--- a/resources/public/api/conf/2.0/testdata/fund-release.md
+++ b/resources/public/api/conf/2.0/testdata/fund-release.md
@@ -13,7 +13,7 @@
                   <p>Fund release created</p>
                   <p class="code--block">
                   <strong>lisaManagerReferenceNumber:</strong><br>
-                  <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                  <a href="#testing">Use your test user profile</a><br>
                    <br>
                         <strong>accountId:</strong><br>1234567890
                   </p>
@@ -50,7 +50,7 @@
                          <p>Fund release superseded</p>
                          <p class="code--block">
                             <strong>lisaManagerReferenceNumber:</strong><br>
-                            <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                            <a href="#testing">Use your test user profile</a><br>
                                <br>
                                    <strong>accountId:</strong><br>1234567890
                            </p>
@@ -119,7 +119,7 @@
                                                     <p>Invalid Account ID</p>
                                                     <p class="code--block">
                                                         <strong>lisaManagerReferenceNumber:</strong><br>
-                                                        <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                        <a href="#testing">Use your test user profile</a><br>
                                                         <br>
                                                         <strong>accountId:</strong><br>1234%3D5678
                                                     </p>
@@ -152,7 +152,7 @@
                                                     <p>This LISA account is already closed</p>
                                                     <p class="code--block">
                                                         <strong>lisaManagerReferenceNumber:</strong><br>
-                                                        <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                        <a href="#testing">Use your test user profile</a><br>
                                                         <br>
                                                         <strong>accountId:</strong><br>1000000403
                                                     </p>
@@ -185,7 +185,7 @@
                                                                     <p>This LISA account is already void</p>
                                                                     <p class="code--block">
                                                                     <strong>lisaManagerReferenceNumber:</strong><br>
-                                                                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                                    <a href="#testing">Use your test user profile</a><br>
                                                                      <br>
                                                                      <strong>accountId:</strong><br>3000000403
                                                                      </p>
@@ -218,7 +218,7 @@
                                                                         <p>This LISA account is already cancelled</p>
                                                                         <p class="code--block">
                                                                         <strong>lisaManagerReferenceNumber:</strong><br>
-                                                                        <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                                        <a href="#testing">Use your test user profile</a><br>
                                                                           <br>
                                                                               <strong>accountId:</strong><br>2000000403
                                                                               </p>
@@ -251,7 +251,7 @@
                                                                                             <p>Account not open long enough</p>
                                                                                             <p class="code--block">
                                                                                             <strong>lisaManagerReferenceNumber:</strong><br>
-                                                                                            <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                                                            <a href="#testing">Use your test user profile</a><br>
                                                                                             <br>
                                                                                             <strong>accountId:</strong><br>4000000403
                                                                                             </p>
@@ -284,7 +284,7 @@
                                                                                                   <p>Other purchase on record</p>
                                                                                                   <p class="code--block">
                                                                                                   <strong>lisaManagerReferenceNumber:</strong><br>
-                                                                                                  <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                                                                  <a href="#testing">Use your test user profile</a><br>
                                                                                                    <br>
                                                                                                     <strong>accountId:</strong><br>6000000403
                                                                                                    </p>
@@ -317,7 +317,7 @@
                                                                                                   <p>Supersede details do not match the original request</p>
                                                                                                   <p class="code--block">
                                                                                                   <strong>lisaManagerReferenceNumber:</strong><br>
-                                                                                                  <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                                                                  <a href="#testing">Use your test user profile</a><br>
                                                                                                <br>
                                                                                                   <strong>accountId:</strong><br>5000000403
                                                                                                   </p>
@@ -349,7 +349,7 @@
                                                                                                        <p>Invalid Data Provided</p>
                                                                                                        <p class="code--block">
                                                                                                        <strong>lisaManagerReferenceNumber:</strong><br>
-                                                                                                       <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                                                                       <a href="#testing">Use your test user profile</a><br>
                                                                                                        <br>
                                                                                                        <strong>accountId:</strong><br>1234567890
                                                                                                        </p>
@@ -386,7 +386,7 @@
                                                                                                        <p>Account ID does not exist</p>
                                                                                                        <p class="code--block">
                                                                                                        <strong>lisaManagerReferenceNumber:</strong><br>
-                                                                                                       <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                                                                       <a href="#testing">Use your test user profile</a><br>
                                                                                                    <br>
                                                                                                        <strong>accountId:</strong><br>0000000404
                                                                                                        </p>
@@ -419,7 +419,7 @@
                                                                                                   <p>The fund release you are superseding has already been superseded</p>
                                                                                                   <p class="code--block">
                                                                                                   <strong>lisaManagerReferenceNumber:</strong><br>
-                                                                                                  <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                                                                  <a href="#testing">Use your test user profile</a><br>
                                                                                               <br>
                                                                                               <strong>accountId:</strong><br>1000000409
                                                                                               </p>
@@ -451,7 +451,7 @@
                                                                                         <p>Fund release already exists</p>
                                                                                         <p class="code--block">
                                                                                         <strong>lisaManagerReferenceNumber:</strong><br>
-                                                                                        <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                                                                                        <a href="#testing">Use your test user profile</a><br>
                                                                                         <br>
                                                                                         <strong>accountId:</strong><br>0000000409
                                                                                         </p>

--- a/resources/public/api/conf/2.0/testdata/get-account.md
+++ b/resources/public/api/conf/2.0/testdata/get-account.md
@@ -12,7 +12,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number and account ID (open account)</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 1234567890
         </p>
       </td>
@@ -34,7 +34,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number and account ID (transferred account)</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 1234567891
         </p>
       </td>
@@ -61,7 +61,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number and account ID (voided account)</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 1000000200
         </p>
       </td>
@@ -83,7 +83,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number and account ID (closed account)</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 2000000200
         </p>
       </td>
@@ -125,7 +125,7 @@
       <td>
         <p>Request with a valid LISA Manager reference number, but an invalid account ID</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
           accountId: 1234%3D5678
         </p>
       </td>
@@ -143,7 +143,7 @@
         <td>
             <p>Request containing an account ID that does not exist</p>
             <p class="code--block">
-                lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                 accountId: 0000000404
             </p>
         </td>
@@ -161,7 +161,7 @@
       <td>
         <p>Request with an invalid 'Accept' header</p>
         <p class="code--block">
-          lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+          lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
           <br>accountId: 1234567890<br>
           <br>
           Accept: application/vnd.hmrc.1.0

--- a/resources/public/api/conf/2.0/testdata/get-bulk-payment.md
+++ b/resources/public/api/conf/2.0/testdata/get-bulk-payment.md
@@ -12,7 +12,7 @@
             <td>
                 <p>Request for payments where some are found</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-05-20<br>
                     endDate: 2017-10-20
                 </p>
@@ -57,7 +57,7 @@
             <td>
                 <p>Request for payments where none are found</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-04-06<br>
                     endDate: 2017-04-06
                 </p>
@@ -91,7 +91,7 @@
             <td>
                 <p>Request with startDate in the wrong format</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 20-05-2017<br>
                     endDate: 2017-05-20
                 </p>
@@ -109,7 +109,7 @@
             <td>
                 <p>Request with endDate in the wrong format</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-05-20<br>
                     endDate: 20-05-2017
                 </p>
@@ -127,7 +127,7 @@
             <td>
                 <p>Request with startDate and endDate in the wrong format</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 20-05-2017<br>
                     endDate: 20-05-2017
                 </p>
@@ -145,7 +145,7 @@
             <td>
                 <p>Request with and endDate in the future</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: (today's date)<br>
                     endDate: (any date in the future)
                 </p>
@@ -163,7 +163,7 @@
             <td>
                 <p>Request with an endDate before the startDate</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-12-20<br>
                     endDate: 2017-12-19
                 </p>
@@ -181,7 +181,7 @@
             <td>
                 <p>Request with an endDate before the startDate</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-04-05<br>
                     endDate: 2017-04-06
                 </p>
@@ -199,7 +199,7 @@
             <td>
                 <p>Request with an endDate over a year after startDate</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-04-06<br>
                     endDate: 2018-04-07
                 </p>
@@ -217,7 +217,7 @@
             <td>
                 <p>Request with an invalid 'Accept' header</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>
                     startDate: 2017-04-06<br>
                     endDate: 2017-05-05
                     <br>

--- a/resources/public/api/conf/2.0/testdata/get-investor-payment.md
+++ b/resources/public/api/conf/2.0/testdata/get-investor-payment.md
@@ -9,7 +9,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request for a paid payment</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0123456789</p></td>
+            <td><p>Request for a paid payment</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0123456789</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -24,7 +24,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a pending transaction (payment or debt)</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0000000200</p></td>
+            <td><p>Request for a pending transaction (payment or debt)</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0000000200</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -35,7 +35,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a pending payment with a due date</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 3000000200</p></td>
+            <td><p>Request for a pending payment with a due date</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 3000000200</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -48,7 +48,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a cancelled transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 1000000200</p></td>
+            <td><p>Request for a cancelled transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 1000000200</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -59,7 +59,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a void transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2000000200</p></td>
+            <td><p>Request for a void transaction</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2000000200</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -70,7 +70,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a debt which is due to be collected</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2345678902</p></td>
+            <td><p>Request for a debt which is due to be collected</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2345678902</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -83,7 +83,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a debt which has been collected</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2345678903</p></td>
+            <td><p>Request for a debt which has been collected</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2345678903</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -98,7 +98,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a transaction which was superseded before being paid</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2345678901</p></td>
+            <td><p>Request for a transaction which was superseded before being paid</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 2345678901</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -121,7 +121,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid LISA Manager reference number and Transaction ID, but an invalid account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234%3D5678<br>transactionId: 0123456789</p></td>
+            <td><p>Request with a valid LISA Manager reference number and Transaction ID, but an invalid account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234%3D5678<br>transactionId: 0123456789</p></td>
             <td><p>HTTP status: <code class="code--slim">400 (Bad Request)</code></p>
 <pre class="code--block">
 {
@@ -132,7 +132,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for a transaction that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0000000404</p></td>
+            <td><p>Request for a transaction that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0000000404</p></td>
             <td><p>HTTP status: <code class="code--slim">404 (Not Found)</code></p>
 <pre class="code--block">
 {
@@ -143,7 +143,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567899<br>transactionId: 1000000404</p></td>
+            <td><p>Request for an account that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567899<br>transactionId: 1000000404</p></td>
             <td><p>HTTP status: <code class="code--slim">404 (Not Found)</code></p>
 <pre class="code--block">
 {
@@ -154,7 +154,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0123456789<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>transactionId: 0123456789<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td><p>HTTP status: <code class="code--slim">406 (Not Acceptable)</code></p>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/life-event-get.md
+++ b/resources/public/api/conf/2.0/testdata/life-event-get.md
@@ -9,7 +9,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid LISA Manager reference number, account ID and life event ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>lifeEventId: 1234567891</p></td>
+            <td><p>Request with a valid LISA Manager reference number, account ID and life event ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>lifeEventId: 1234567891</p></td>
             <td><p>HTTP status: <code class="code--slim">200 (OK)</code></p>
 <pre class="code--block">
 {
@@ -32,7 +32,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000404<br>lifeEventId: 1234567891</p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000404<br>lifeEventId: 1234567891</p></td>
             <td><p>HTTP status: <code class="code--slim">404 (Not found)</code></p>
 <pre class="code--block">
 {
@@ -43,7 +43,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1000000404<br>lifeEventId: 1234567890</p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1000000404<br>lifeEventId: 1234567890</p></td>
             <td><p>HTTP status: <code class="code--slim">404 (Not found)</code></p>
 <pre class="code--block">
 {
@@ -54,7 +54,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br>lifeEventId: 1234567891<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br>lifeEventId: 1234567891<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td><p>HTTP status: <code class="code--slim">406 (Not Acceptable)</code></p>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/life-event.md
+++ b/resources/public/api/conf/2.0/testdata/life-event.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -53,7 +53,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
+            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
             <td>
 <pre class="code--block">
 {
@@ -72,7 +72,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -102,7 +102,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an event date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing an event date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -128,7 +128,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a life event that conflicts with a previously reported event</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000403</p></td>
+            <td><p>Request containing a life event that conflicts with a previously reported event</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000403</p></td>
             <td>
 <pre class="code--block">
 {
@@ -147,7 +147,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been closed or voided</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000903</p></td>
+            <td><p>Request for an account that has already been closed or voided</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000903</p></td>
             <td>
 <pre class="code--block">
 {
@@ -166,7 +166,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
             <td>
 <pre class="code--block">
 {
@@ -185,7 +185,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
 <pre class="code--block">
 {
@@ -204,7 +204,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an already reported event</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000409</p></td>
+            <td><p>Request containing an already reported event</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000409</p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/lisa-create-investor.md
+++ b/resources/public/api/conf/2.0/testdata/lisa-create-investor.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload and LISA Manager reference number</p> <p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request with a valid payload and LISA Manager reference number</p> <p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -57,7 +57,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -99,7 +99,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing investor details which do not match HMRC’s records</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing investor details which do not match HMRC’s records</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -120,7 +120,7 @@
              </td>
         </tr>
         <tr>
-           <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br><br>Accept: application/vnd.hmrc.1.0</p></td>
+           <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br><br>Accept: application/vnd.hmrc.1.0</p></td>
            <td>
 <pre class="code--block">
 {
@@ -141,7 +141,7 @@
            </td>
         </tr>
         <tr>
-            <td><p>Request containing a pre-existing investor’s details</p> <p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing a pre-existing investor’s details</p> <p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/reinstate-account.md
+++ b/resources/public/api/conf/2.0/testdata/reinstate-account.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -55,7 +55,7 @@
             <td>
                 <p>Request with a invalid payload</p>
                 <p class="code--block">
-                    lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a>
+                    lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a>
                 </p>
             </td>
             <td>
@@ -82,7 +82,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that is open or active</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for an account that is open or active</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -100,7 +100,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that is closed with a closure reason as transferred out</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for an account that is closed with a closure reason as transferred out</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -118,7 +118,7 @@
             </td>
         </tr>
          <tr>
-            <td><p>Request for an account that is closed with a closure reason as cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for an account that is closed with a closure reason as cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -136,7 +136,7 @@
             </td>
         </tr>
          <tr>
-            <td><p>Request for an account that is closed with a closure reason as cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request for an account that is closed with a closure reason as cancelled</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {
@@ -154,7 +154,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a></p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a></p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/subscription-update.md
+++ b/resources/public/api/conf/2.0/testdata/subscription-update.md
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -34,7 +34,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567891</p></td>
+            <td><p>Request with a valid payload, LISA Manager reference number and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567891</p></td>
             <td>
 <pre class="code--block">
 {
@@ -75,7 +75,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
+            <td><p>Request with a valid payload and LISA Manager reference number, but an invalid and account ID</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234%3D5678</p></td>
             <td>
 <pre class="code--block">
 {
@@ -93,7 +93,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing invalid and/or missing data</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -118,7 +118,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing a first subscription date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
+            <td><p>Request containing a first subscription date before 6 April 2017</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890</p></td>
             <td>
 <pre class="code--block">
 {
@@ -143,7 +143,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been closed</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000901</p></td>
+            <td><p>Request for an account that has already been closed</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000901</p></td>
             <td>
 <pre class="code--block">
 {
@@ -161,7 +161,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request for an account that has already been void</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000902</p></td>
+            <td><p>Request for an account that has already been void</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000902</p></td>
             <td>
 <pre class="code--block">
 {
@@ -179,7 +179,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
+            <td><p>Request containing an account ID that does not exist</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 0000000404</p></td>
             <td>
 <pre class="code--block">
 {
@@ -197,7 +197,7 @@
             </td>
         </tr>
         <tr>
-            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
+            <td><p>Request with an invalid 'Accept' header</p><p class="code--block">lisaManagerReferenceNumber: <a href="#testing">Use your test user profile</a><br>accountId: 1234567890<br><br>Accept: application/vnd.hmrc.1.0</p></td>
             <td>
 <pre class="code--block">
 {

--- a/resources/public/api/conf/2.0/testdata/withdrawal-charge-get.md
+++ b/resources/public/api/conf/2.0/testdata/withdrawal-charge-get.md
@@ -13,7 +13,7 @@
                 <p>Withdrawal transaction which has been superseded</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                     <br>
@@ -41,7 +41,7 @@
                 <p>Withdrawal transaction which has not been superseded</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                     <br>
@@ -68,7 +68,7 @@
                 <p>Withdrawal transaction which supersedes another</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                     <br>
@@ -123,7 +123,7 @@
                 <p>Invalid Account ID</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234%3D5678
                     <br>
@@ -145,7 +145,7 @@
                 <p>Account ID does not exist</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                     <br>
@@ -167,7 +167,7 @@
                 <p>Transaction ID does not exist</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                     <br>

--- a/resources/public/api/conf/2.0/testdata/withdrawal-charge.md
+++ b/resources/public/api/conf/2.0/testdata/withdrawal-charge.md
@@ -15,7 +15,7 @@
                 <p>Unauthorised withdrawal transaction created</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                 </p>
@@ -53,7 +53,7 @@
                 <p>Unauthorised withdrawal transaction created - late notification</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567891
                 </p>
@@ -91,7 +91,7 @@
                 <p>Unauthorised withdrawal transaction superseded</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                 </p>
@@ -135,7 +135,7 @@
                 <p>Invalid and/or missing data</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                 </p>
@@ -229,7 +229,7 @@
                 <p>Invalid Account ID</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234%3D5678
                 </p>
@@ -264,7 +264,7 @@
                 <p>Invalid monetary amounts and/or invalid dates</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                 </p>
@@ -315,7 +315,7 @@
                 <p>This LISA account is already cancelled</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1000000403
                 </p>
@@ -349,7 +349,7 @@
                 <p>This LISA account is already void</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>2000000403
                 </p>
@@ -383,7 +383,7 @@
                 <p>A superseded withdrawal report cannot be matched to the original</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>3000000403
                 </p>
@@ -423,7 +423,7 @@
                 <p>The withdrawal charge has already been superseded</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>4000000403
                 </p>
@@ -463,7 +463,7 @@
                 <p>The calculation from your superseded withdrawal charge is incorrect</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>5000000403
                 </p>
@@ -503,7 +503,7 @@
                 <p>The withdrawal charge does not equal 25% of the withdrawal amount</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>6000000403
                 </p>
@@ -543,7 +543,7 @@
                 <p>Account ID does not exist</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>0000000404
                 </p>
@@ -577,7 +577,7 @@
                 <p>The accept header is invalid</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>1234567890
                     <br>
@@ -614,7 +614,7 @@
                 <p>Withdrawl charge has already been reported</p>
                 <p class="code--block">
                     <strong>lisaManagerReferenceNumber:</strong><br>
-                    <a href="https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/lisa-api/1.0#testing">Use your test user profile</a><br>
+                    <a href="#testing">Use your test user profile</a><br>
                     <br>
                     <strong>accountId:</strong><br>0000000409
                 </p>


### PR DESCRIPTION
They all used an absolute URL which specifically pointed to v1.0 of the API
spec. They have now all been replaced with a relative link for whichever
version of the spec the user is looking at.