### PR TITLE
API documentation update for v1.0

### DIFF
--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -1045,7 +1045,7 @@ types:
                       example: "2017-05-06"
                     endDate:
                       type : ISO8601Date
-                      description: The last date of the claim period you want to search. This must be the 5th day of the month. This cannot be in the future, before the periodStartDate, or more than a year after the periodStartDate. It must be at least one month after the periodStartDate.
+                      description: The last date of the claim period you want to search. This must be the 5th day of the month. This cannot be in the future, before the startDate, or more than a year after the startDate. It must be at least one month after the startDate.
                       example: "2017-06-05"
                   responses:
                       200:


### PR DESCRIPTION
The endDate description for "Get a list of all payments in a date range" references periodStartDate, when it should reference startDate.