### PR TITLE
LISA-2403: Added feature flag to send an annual return API

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/config/AppContext.scala
+++ b/app/uk/gov/hmrc/lisaapi/config/AppContext.scala
@@ -40,9 +40,7 @@ class AppContext @Inject()(
 
   override protected def mode = environment.mode
 
-  def endpointIsEnabled(endpoint: String): Boolean = {
-    val endpointIsDisabled = runModeConfiguration.getStringList("api.disabledEndpoints").fold(false)(list => list.contains(endpoint))
-
-    !endpointIsDisabled
+  def endpointIsDisabled(endpoint: String): Boolean = {
+    runModeConfiguration.getStringList("api.disabledEndpoints").fold(false)(list => list.contains(endpoint))
   }
 }

--- a/app/uk/gov/hmrc/lisaapi/config/AppContext.scala
+++ b/app/uk/gov/hmrc/lisaapi/config/AppContext.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.lisaapi.config
 
-
 import com.google.inject.Inject
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.play.config.ServicesConfig
@@ -40,4 +39,10 @@ class AppContext @Inject()(
   lazy val v2endpointsEnabled = runModeConfiguration.getBoolean("api.endpointsEnabledv2").getOrElse(throw new RuntimeException(s"Missing key api.endpointsEnabledv2"))
 
   override protected def mode = environment.mode
+
+  def endpointIsEnabled(endpoint: String): Boolean = {
+    val endpointIsDisabled = runModeConfiguration.getStringList("api.disabledEndpoints").fold(false)(list => list.contains(endpoint))
+
+    !endpointIsDisabled
+  }
 }

--- a/app/uk/gov/hmrc/lisaapi/controllers/APIVersioning.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/APIVersioning.scala
@@ -31,6 +31,18 @@ trait APIVersioning {
 
   protected def appContext: AppContext
 
+  def isEndpointEnabled(endpoint: String): ActionBuilder[Request] = new ActionBuilder[Request] {
+    override def invokeBlock[A](request: Request[A], block: Request[A] => Future[Result]): Future[Result] = {
+      if (appContext.endpointIsEnabled(endpoint)) {
+        block(request)
+      }
+      else {
+        Logger.info(s"User attempted to use an endpoint which is not available ($endpoint)")
+        Future.successful(ErrorNotImplemented.asResult)
+      }
+    }
+  }
+
   def validateHeader(): ActionBuilder[Request] = new ActionBuilder[Request] {
     override def invokeBlock[A](request: Request[A], block: Request[A] => Future[Result]) = {
       extractAcceptHeader(request) match {

--- a/app/uk/gov/hmrc/lisaapi/controllers/APIVersioning.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/APIVersioning.scala
@@ -33,12 +33,12 @@ trait APIVersioning {
 
   def isEndpointEnabled(endpoint: String): ActionBuilder[Request] = new ActionBuilder[Request] {
     override def invokeBlock[A](request: Request[A], block: Request[A] => Future[Result]): Future[Result] = {
-      if (appContext.endpointIsEnabled(endpoint)) {
-        block(request)
-      }
-      else {
+      if (appContext.endpointIsDisabled(endpoint)) {
         Logger.info(s"User attempted to use an endpoint which is not available ($endpoint)")
         Future.successful(ErrorNotImplemented.asResult)
+      }
+      else {
+        block(request)
       }
     }
   }

--- a/app/uk/gov/hmrc/lisaapi/controllers/AnnualReturnController.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/AnnualReturnController.scala
@@ -43,7 +43,7 @@ class AnnualReturnController @Inject()(
 
   override val validateVersion: String => Boolean = _ == "2.0"
 
-  def submitReturn(lisaManager: String, accountId: String): Action[AnyContent] = validateHeader().async {
+  def submitReturn(lisaManager: String, accountId: String): Action[AnyContent] = (validateHeader() andThen isEndpointEnabled("annual-returns")).async {
     implicit request =>
       implicit val startTime: Long = System.currentTimeMillis()
 

--- a/app/uk/gov/hmrc/lisaapi/controllers/Responses.scala
+++ b/app/uk/gov/hmrc/lisaapi/controllers/Responses.scala
@@ -92,7 +92,7 @@ case object ErrorBadRequestStartBefore6April2017 extends ErrorResponse(403, "FOR
 case object ErrorBadRequestOverYearBetweenStartAndEnd extends ErrorResponse(403, "FORBIDDEN", "endDate cannot be more than a year after startDate")
 // end
 
-case object ErrorNotImplemented extends ErrorResponse(501, "NOT_IMPLEMENTED", "Not implemented")
+case object ErrorNotImplemented extends ErrorResponse(501, "NOT_IMPLEMENTED", "API not implemented/deployed")
 
 case object ErrorUnauthorized extends ErrorResponse(401, "UNAUTHORIZED", "Bearer token is missing or not authorized")
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -115,26 +115,27 @@ logger.application=DEBUG
 
 # Metrics plugin settings - graphite reporting is configured on a per env basis
 metrics {
-    name = ${appName}
-    rateUnit = SECONDS
-    durationUnit = SECONDS
-    showSamples = true
-    jvm = true
-    enabled = true
+  name = ${appName}
+  rateUnit = SECONDS
+  durationUnit = SECONDS
+  showSamples = true
+  jvm = true
+  enabled = true
 }
 
 api {
-    context = "lifetime-isa"
-    status="BETA"
-    statusv2="BETA"
-    endpointsEnabled=true
-    endpointsEnabledv2=true
-    access {
-      type = "PUBLIC"
-      white-list {
-        applicationIds = []
-      }
+  context = "lifetime-isa"
+  status = "BETA"
+  statusv2 = "BETA"
+  endpointsEnabled = true
+  endpointsEnabledv2 = true
+  access {
+    type = "PUBLIC"
+    white-list {
+      applicationIds = []
     }
+  }
+  disabledEndpoints = []
 }
 
 auditing {

--- a/resources/public/api/conf/2.0/application.raml
+++ b/resources/public/api/conf/2.0/application.raml
@@ -789,8 +789,8 @@ types:
                   /annual-returns:
                     post:
                       is: [headers.acceptHeader, headers.contentHeader]
-                      displayName: Send an annual return of information
-                      description: Report details to HMRC about LISA accounts you managed in the last tax year. You can also correct a previous return of information. You cannot send or correct a return of information if the investor account is cancelled or void.
+                      displayName: "[Sandbox only] Send an annual return of information"
+                      description: "**This API is not currently available in Production.** Report details to HMRC about LISA accounts you managed in the last tax year. You can also correct a previous return of information. You cannot send or correct a return of information if the investor account is cancelled or void."
                       (annotations.scope): "write:lisa"
                       (annotations.sandboxData): !include testdata/annual-return.md
                       securedBy: [ sec.oauth_2_0: { scopes: [ "write:lisa" ] } ]

--- a/test/unit/config/APIAccessConfigSpec.scala
+++ b/test/unit/config/APIAccessConfigSpec.scala
@@ -29,7 +29,7 @@ class APIAccessConfigSpec extends PlaySpec with MockitoSugar {
   val mockConfiguration = mock[Configuration]
   val apiAccessConfigMocked = APIAccessConfig(Some(mockConfiguration))
 
-    "APIAccessConfig created with no Configuration" should {
+  "APIAccessConfig created with no Configuration" should {
     "return private for type" in {
       apiAccessConfigNone.accessType must be ("PUBLIC")
     }

--- a/test/unit/config/AppContextSpec.scala
+++ b/test/unit/config/AppContextSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.config
+
+import collection.JavaConverters._
+import org.mockito.Matchers._
+import org.mockito.Mockito.when
+import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import play.api.{Configuration, Environment}
+import uk.gov.hmrc.lisaapi.config.AppContext
+
+class AppContextSpec extends PlaySpec with MockitoSugar {
+
+  val mockEnvironment = mock[Environment]
+  val mockConfiguration = mock[Configuration]
+  val SUT = new AppContext(mockConfiguration, mockEnvironment)
+
+  "endpointIsEnabled" must {
+
+    "return true if there are no disabled endpoints in the config" in {
+      when(mockConfiguration.getStringList(any())).thenReturn(None)
+
+      SUT.endpointIsEnabled("test1") mustBe true
+    }
+
+    "return true if the named endpoint isn't in the disabled list" in {
+      when(mockConfiguration.getStringList(any())).thenReturn(Some(List[String]("test1").asJava))
+
+      SUT.endpointIsEnabled("test2") mustBe true
+    }
+
+    "return false if the named endpoint is in the disabled list" in {
+      when(mockConfiguration.getStringList(any())).thenReturn(Some(List[String]("test1", "test2", "test3").asJava))
+
+      SUT.endpointIsEnabled("test3") mustBe false
+    }
+
+  }
+
+}

--- a/test/unit/config/AppContextSpec.scala
+++ b/test/unit/config/AppContextSpec.scala
@@ -30,24 +30,24 @@ class AppContextSpec extends PlaySpec with MockitoSugar {
   val mockConfiguration = mock[Configuration]
   val SUT = new AppContext(mockConfiguration, mockEnvironment)
 
-  "endpointIsEnabled" must {
+  "endpointIsDisabled" must {
 
-    "return true if there are no disabled endpoints in the config" in {
+    "return false if there are no disabled endpoints in the config" in {
       when(mockConfiguration.getStringList(any())).thenReturn(None)
 
-      SUT.endpointIsEnabled("test1") mustBe true
+      SUT.endpointIsDisabled("test1") mustBe false
     }
 
-    "return true if the named endpoint isn't in the disabled list" in {
+    "return false if the named endpoint isn't in the disabled list" in {
       when(mockConfiguration.getStringList(any())).thenReturn(Some(List[String]("test1").asJava))
 
-      SUT.endpointIsEnabled("test2") mustBe true
+      SUT.endpointIsDisabled("test2") mustBe false
     }
 
-    "return false if the named endpoint is in the disabled list" in {
+    "return true if the named endpoint is in the disabled list" in {
       when(mockConfiguration.getStringList(any())).thenReturn(Some(List[String]("test1", "test2", "test3").asJava))
 
-      SUT.endpointIsEnabled("test3") mustBe false
+      SUT.endpointIsDisabled("test3") mustBe true
     }
 
   }

--- a/test/unit/controllers/APIVersioningSpec.scala
+++ b/test/unit/controllers/APIVersioningSpec.scala
@@ -87,13 +87,13 @@ class APIVersioningSpec extends PlaySpec with MockitoSugar with OneAppPerSuite {
   }
 
   "The isEndpointEnabled function" must {
-    "allow execution if the appContext returns that the endpoint is enabled" in {
-      when(mockAppContext.endpointIsEnabled("test")).thenReturn(true)
+    "allow execution if the appContext returns that the endpoint is not disabled" in {
+      when(mockAppContext.endpointIsDisabled("test")).thenReturn(false)
       val request = FakeRequest(Helpers.GET, "/").withHeaders((ACCEPT, "application/vnd.hmrc.2.0+json"))
       isEndpointEnabledTest(request) mustBe Results.Ok
     }
-    "return a not implemented error if the appContext returns that the endpoint is not enabled" in {
-      when(mockAppContext.endpointIsEnabled("test")).thenReturn(false)
+    "return a not implemented error if the appContext returns that the endpoint is disabled" in {
+      when(mockAppContext.endpointIsDisabled("test")).thenReturn(true)
       val request = FakeRequest(Helpers.GET, "/").withHeaders((ACCEPT, "application/vnd.hmrc.2.0+json"))
       isEndpointEnabledTest(request) mustBe ErrorNotImplemented.asResult
     }

--- a/test/unit/controllers/APIVersioningSpec.scala
+++ b/test/unit/controllers/APIVersioningSpec.scala
@@ -16,6 +16,7 @@
 
 package unit.controllers
 
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.http.HeaderNames.ACCEPT
@@ -23,7 +24,7 @@ import play.api.mvc._
 import play.api.test.{FakeApplication, FakeRequest}
 import play.test.Helpers
 import uk.gov.hmrc.lisaapi.config.AppContext
-import uk.gov.hmrc.lisaapi.controllers.{APIVersioning, ErrorAcceptHeaderContentInvalid, ErrorAcceptHeaderInvalid, ErrorAcceptHeaderVersionInvalid}
+import uk.gov.hmrc.lisaapi.controllers.{APIVersioning, ErrorAcceptHeaderContentInvalid, ErrorAcceptHeaderInvalid, ErrorAcceptHeaderVersionInvalid, ErrorNotImplemented}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -85,12 +86,32 @@ class APIVersioningSpec extends PlaySpec with MockitoSugar with OneAppPerSuite {
 
   }
 
+  "The isEndpointEnabled function" must {
+    "allow execution if the appContext returns that the endpoint is enabled" in {
+      val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(Helpers.GET, "/").withHeaders((ACCEPT, "application/vnd.hmrc.2.0+json"))
+
+      when(mockAppContext.endpointIsEnabled("test")).thenReturn(true)
+
+      isEndpointEnabledTest(request) mustBe Results.Ok
+
+    }
+    "return a not implemented error if the appContext returns that the endpoint is not enabled" in {
+      val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(Helpers.GET, "/").withHeaders((ACCEPT, "application/vnd.hmrc.2.0+json"))
+
+      when(mockAppContext.endpointIsEnabled("test")).thenReturn(false)
+
+      isEndpointEnabledTest(request) mustBe ErrorNotImplemented.asResult
+    }
+  }
+
+  val mockAppContext = mock[AppContext]
+
   object APIVersioningImpl extends APIVersioning {
     override val validateVersion: String => Boolean = List("1.0", "2.0") contains _
     override val validateContentType: String => Boolean = _ == "json"
     override lazy val v2endpointsEnabled: Boolean = true
 
-    override protected def appContext: AppContext = ???
+    override protected def appContext: AppContext = mockAppContext
   }
 
   object APIVersioningImplV2Disabled extends APIVersioning {
@@ -98,7 +119,7 @@ class APIVersioningSpec extends PlaySpec with MockitoSugar with OneAppPerSuite {
     override val validateContentType: String => Boolean = _ == "json"
     override lazy val v2endpointsEnabled: Boolean = false
 
-    override protected def appContext: AppContext = ???
+    override protected def appContext: AppContext = mockAppContext
   }
 
   def withApiVersionTest[A](request: Request[A]): Result = {
@@ -110,6 +131,14 @@ class APIVersioningSpec extends PlaySpec with MockitoSugar with OneAppPerSuite {
 
   def validateHeaderTest[A](request: Request[A]): Result = {
     val builder = APIVersioningImpl.validateHeader()
+    val response = builder.invokeBlock[A](
+      request,
+      (_) => Future.successful(Results.Ok))
+    Await.result(response, 100 millis)
+  }
+
+  def isEndpointEnabledTest[A](request: Request[A]): Result = {
+    val builder = APIVersioningImpl.isEndpointEnabled("test")
     val response = builder.invokeBlock[A](
       request,
       (_) => Future.successful(Results.Ok))

--- a/test/unit/controllers/APIVersioningSpec.scala
+++ b/test/unit/controllers/APIVersioningSpec.scala
@@ -88,18 +88,13 @@ class APIVersioningSpec extends PlaySpec with MockitoSugar with OneAppPerSuite {
 
   "The isEndpointEnabled function" must {
     "allow execution if the appContext returns that the endpoint is enabled" in {
-      val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(Helpers.GET, "/").withHeaders((ACCEPT, "application/vnd.hmrc.2.0+json"))
-
       when(mockAppContext.endpointIsEnabled("test")).thenReturn(true)
-
+      val request = FakeRequest(Helpers.GET, "/").withHeaders((ACCEPT, "application/vnd.hmrc.2.0+json"))
       isEndpointEnabledTest(request) mustBe Results.Ok
-
     }
     "return a not implemented error if the appContext returns that the endpoint is not enabled" in {
-      val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(Helpers.GET, "/").withHeaders((ACCEPT, "application/vnd.hmrc.2.0+json"))
-
       when(mockAppContext.endpointIsEnabled("test")).thenReturn(false)
-
+      val request = FakeRequest(Helpers.GET, "/").withHeaders((ACCEPT, "application/vnd.hmrc.2.0+json"))
       isEndpointEnabledTest(request) mustBe ErrorNotImplemented.asResult
     }
   }

--- a/test/unit/controllers/AnnualReturnControllerSpec.scala
+++ b/test/unit/controllers/AnnualReturnControllerSpec.scala
@@ -51,7 +51,7 @@ class AnnualReturnControllerSpec extends PlaySpec
 
     when(mockAuthCon.authorise[Option[String]](any(),any())(any(), any())).thenReturn(Future(Some("1234")))
     when(mockValidator.validate(any())).thenReturn(Nil)
-    when(mockAppContext.endpointIsEnabled(any())).thenReturn(true)
+    when(mockAppContext.endpointIsDisabled(any())).thenReturn(false)
   }
 
   "Submit annual return" must {

--- a/test/unit/controllers/AnnualReturnControllerSpec.scala
+++ b/test/unit/controllers/AnnualReturnControllerSpec.scala
@@ -51,6 +51,7 @@ class AnnualReturnControllerSpec extends PlaySpec
 
     when(mockAuthCon.authorise[Option[String]](any(),any())(any(), any())).thenReturn(Future(Some("1234")))
     when(mockValidator.validate(any())).thenReturn(Nil)
+    when(mockAppContext.endpointIsEnabled(any())).thenReturn(true)
   }
 
   "Submit annual return" must {


### PR DESCRIPTION
It's now possible to disable this endpoint via config.

There is a "disabledEndpoints" list in the config, adding "annual-returns" to this will disable the endpoint and cause a NOT_IMPLEMENTED error to be returned to the user.