### PR TITLE
DDCE-8619 - Rewrite LISA API Connector Test to use Wiremock Instead of Mockito

### DIFF
--- a/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
@@ -51,8 +51,9 @@ class DesConnector @Inject() (
     "CorrelationId" -> correlationId
   )
 
-  private def correlationId(implicit hc: HeaderCarrier): String = {
+  private[connectors] def correlationId(implicit hc: HeaderCarrier): String = {
     val CorrelationIdPattern = """.*([A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}).*""".r
+
     hc.requestId match {
       case Some(requestId) =>
         requestId.value match {
@@ -350,18 +351,9 @@ class DesConnector @Inject() (
           case _                   => parseDesResponse[DesTransactionResponse](res)
         }
       }
-      .recover {
-        case response: UpstreamErrorResponse =>
-          if (response.reportAs == 499) {
-            logger.error(s"[DesConnector][requestBonusPayment] Service unavailable")
-            DesUnavailableResponse
-          } else {
-            logger.error(s"[DesConnector][requestBonusPayment] Upstream Des error")
-            DesFailureResponse(response.message, response.message)
-          }
-        case th: Throwable                   =>
-          logger.error(s"[DesConnector][requestBonusPayment] Des failure error: " + th.getMessage)
-          DesFailureResponse()
+      .recover { case th: Throwable =>
+        logger.error(s"[DesConnector][requestBonusPayment] Des failure error: " + th.getMessage)
+        DesFailureResponse()
       }
   }
 

--- a/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
@@ -79,6 +79,7 @@ class DesConnector @Inject() (
       .withBody(Json.toJson(request))
       .setHeader(desHeaders: _*)
       .execute[HttpResponse]
+
     result.map { res =>
       logger.info("[DesConnector][createInvestor] Create Investor request returned status: " + res.status)
       res.status match {
@@ -97,7 +98,8 @@ class DesConnector @Inject() (
   ): Future[DesResponse] = {
     val fullUrl = s"$lisaServiceUrl/$lisaManager/accounts"
     logger.info("[DesConnector][createAccount] Posting Create Account request to des: " + fullUrl)
-    val result  = wsHttp
+
+    val result = wsHttp
       .post(url"$fullUrl")
       .withBody(Json.toJson(request))
       .setHeader(desHeaders: _*)
@@ -119,8 +121,10 @@ class DesConnector @Inject() (
   def getAccountInformation(lisaManager: String, accountId: String)(implicit hc: HeaderCarrier): Future[DesResponse] = {
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}"
+
     logger.info("[DesConnector][getAccountInformation] Getting the Account details from des: " + fullUrl)
-    val result  = wsHttp
+
+    val result = wsHttp
       .get(url"$fullUrl")
       .setHeader(desHeadersWithOriginator: _*)
       .execute[HttpResponse]
@@ -143,12 +147,15 @@ class DesConnector @Inject() (
   def reinstateAccount(lisaManager: String, accountId: String)(implicit hc: HeaderCarrier): Future[DesResponse] = {
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}/reinstate"
+
     logger.info("[DesConnector][reinstateAccount] Reinstate Account request returned status: " + fullUrl)
-    val result  = wsHttp
+
+    val result = wsHttp
       .put(url"$fullUrl")
       .setHeader(desHeadersWithOriginator: _*)
       .withBody(Json.toJson(""))
       .execute[HttpResponse]
+
     result.map { res =>
       logger.info("[DesConnector][reinstateAccount] Reinstate Account request returned status: " + res.status)
       res.status match {
@@ -167,7 +174,8 @@ class DesConnector @Inject() (
   ): Future[DesResponse] = {
     val fullUrl = s"$lisaServiceUrl/$lisaManager/accounts"
     logger.info("[DesConnector][transferAccount] Posting Create Transfer request to des: " + fullUrl)
-    val result  = wsHttp
+
+    val result = wsHttp
       .post(url"$fullUrl")
       .withBody(Json.toJson(request))
       .setHeader(desHeaders: _*)
@@ -197,6 +205,7 @@ class DesConnector @Inject() (
       .withBody(Json.toJson(request))
       .setHeader(desHeaders: _*)
       .execute[HttpResponse]
+
     result.map { res =>
       logger.info("[DesConnector][closeAccount] Close Account request returned status: " + res.status)
       res.status match {
@@ -216,12 +225,15 @@ class DesConnector @Inject() (
 
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}/life-event"
+
     logger.info("[DesConnector][reportLifeEvent] Posting Life Event request to des: " + fullUrl)
-    val result  = wsHttp
+
+    val result = wsHttp
       .post(url"$fullUrl")
       .withBody(Json.toJson(request))
       .setHeader(desHeaders: _*)
       .execute[HttpResponse]
+
     result.map { res =>
       logger.info("[DesConnector][reportLifeEvent] Life Event request returned status: " + res.status)
       res.status match {
@@ -283,8 +295,10 @@ class DesConnector @Inject() (
 
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}"
+
     logger.info("[DesConnector][updateFirstSubDate] Posting update subscription request to des: " + fullUrl)
-    val result  = wsHttp
+
+    val result = wsHttp
       .put(url"$fullUrl")
       .withBody(Json.toJson(request))
       .setHeader(desHeadersWithOriginator: _*)
@@ -294,6 +308,7 @@ class DesConnector @Inject() (
       logger.info(
         "[DesConnector][updateFirstSubDate] Update first subscription date request returned status: " + res.status
       )
+
       res.status match {
         case OK                  => parseDesResponse[DesUpdateSubscriptionSuccessResponse](res)
         case BAD_REQUEST         => DesBadRequestResponse
@@ -316,12 +331,15 @@ class DesConnector @Inject() (
 
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}/bonus-claim"
+
     logger.info("[DesConnector][requestBonusPayment] Posting Bonus Payment request to des: " + fullUrl)
-    val result  = wsHttp
+
+    val result = wsHttp
       .post(url"$fullUrl")
       .withBody(Json.toJson(request))
       .setHeader(desHeaders: _*)
       .execute[HttpResponse]
+
     result
       .map { res =>
         logger.info("[DesConnector][requestBonusPayment] Bonus Payment request returned status: " + res.status)
@@ -354,6 +372,7 @@ class DesConnector @Inject() (
   ): Future[DesResponse] = {
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}/transaction/$transactionId"
+
     logger.info(
       "[DesConnector][getBonusOrWithdrawal] Getting the Bonus Payment transaction details from des: " + fullUrl
     )
@@ -362,6 +381,7 @@ class DesConnector @Inject() (
       .get(url"$fullUrl")
       .setHeader(desHeadersWithOriginator: _*)
       .execute[HttpResponse]
+
     result.map { res =>
       logger.info(
         "[DesConnector][getBonusOrWithdrawal] Get Bonus Payment transaction details returned status: " + res.status
@@ -384,6 +404,7 @@ class DesConnector @Inject() (
 
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}/withdrawal"
+
     logger.info("[DesConnector][reportWithdrawalCharge] Posting withdrawal request to des: " + fullUrl)
 
     val result = wsHttp
@@ -411,12 +432,14 @@ class DesConnector @Inject() (
   ): Future[DesResponse] = {
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}/transaction/$transactionId/bonusChargeDetails"
+
     logger.info("[DesConnector][getTransaction] Getting the Transaction details from des: " + fullUrl)
 
     val result = wsHttp
       .get(url"$fullUrl")
       .setHeader(desHeadersWithOriginator: _*)
       .execute[HttpResponse]
+
     result.map { res =>
       logger.info("[DesConnector][getTransaction] Get Transaction details returned status: " + res.status)
       res.status match {
@@ -440,6 +463,7 @@ class DesConnector @Inject() (
       .get(url"$fullUrl")
       .setHeader(desHeadersWithOriginator: _*)
       .execute[HttpResponse]
+
     result.map { res =>
       logger.info("[DesConnector][getBulkPayment] Get Bulk payment details returned status: " + res.status)
       res.status match {
@@ -454,6 +478,7 @@ class DesConnector @Inject() (
       .getOrElse(HeaderNames.CONTENT_TYPE, Seq.empty[String])
       .map(_.toLowerCase)
       .exists(_.contains(MimeTypes.JSON.toLowerCase))
+
     if (isJson) {
       res.json.validate[A] match {
         case JsSuccess(value, _) => value

--- a/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
@@ -399,7 +399,7 @@ class DesConnector @Inject() (
     }
   }
 
-  // Attempts to details on a transaction from ETMP
+  // Attempts to get details on a transaction from ETMP
   def getTransaction(lisaManager: String, accountId: String, transactionId: String)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {

--- a/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/lisaapi/connectors/DesConnector.scala
@@ -67,8 +67,7 @@ class DesConnector @Inject() (
   private def desHeadersWithOriginator(implicit hc: HeaderCarrier): Seq[(String, String)] =
     desHeaders :+ ("OriginatorId" -> "DA2_LISA")
 
-  /** Attempts to create a new LISA investor
-    */
+  // Attempts to create a new LISA investor
   def createInvestor(lisaManager: String, request: CreateLisaInvestorRequest)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {
@@ -92,8 +91,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to create a new LISA account
-    */
+  // Attempts to create a new LISA account
   def createAccount(lisaManager: String, request: CreateLisaAccountCreationRequest)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {
@@ -117,8 +115,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to get the details for LISA account
-    */
+  // Attempts to get the details for LISA account
   def getAccountInformation(lisaManager: String, accountId: String)(implicit hc: HeaderCarrier): Future[DesResponse] = {
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}"
@@ -143,8 +140,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to reinstate a LISA account
-    */
+  // Attempts to reinstate a LISA account
   def reinstateAccount(lisaManager: String, accountId: String)(implicit hc: HeaderCarrier): Future[DesResponse] = {
     val fullUrl =
       s"$lisaServiceUrl/$lisaManager/accounts/${UriEncoding.encodePathSegment(accountId, urlEncodingFormat)}/reinstate"
@@ -168,8 +164,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to transfer an existing LISA account
-    */
+  // Attempts to transfer an existing LISA account
   def transferAccount(lisaManager: String, request: CreateLisaAccountTransferRequest)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {
@@ -193,8 +188,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to close a LISA account
-    */
+  // Attempts to close a LISA account
   def closeAccount(lisaManager: String, accountId: String, request: CloseLisaAccountRequest)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {
@@ -218,8 +212,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to report a LISA Life Event
-    */
+  // Attempts to report a LISA Life Event
   def reportLifeEvent(lisaManager: String, accountId: String, request: ReportLifeEventRequestBase)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {
@@ -245,8 +238,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to get a LISA Life Event
-    */
+  // Attempts to get a LISA Life Event
   def getLifeEvent(lisaManager: String, accountId: String, lifeEventId: LifeEventId)(implicit
     hc: HeaderCarrier
   ): Future[Either[DesFailure, Seq[GetLifeEventItem]]] = {
@@ -288,8 +280,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to update the first subscription date
-    */
+  // Attempts to update the first subscription date
   def updateFirstSubDate(lisaManager: String, accountId: String, request: UpdateSubscriptionRequest)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {
@@ -321,11 +312,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to request a bonus payment
-    *
-    * @return
-    *   A tuple of the http status code and a des response
-    */
+  // Attempts to request a bonus payment
   def requestBonusPayment(lisaManager: String, accountId: String, request: RequestBonusPaymentRequest)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {
@@ -357,8 +344,7 @@ class DesConnector @Inject() (
       }
   }
 
-  /** Attempts to get a submitted bonus payment's details from ITMP
-    */
+  // Attempts to get a submitted bonus payment's details from ITMP
   def getBonusOrWithdrawal(lisaManager: String, accountId: String, transactionId: String)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {
@@ -385,11 +371,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to report a withdrawal charge
-    *
-    * @return
-    *   A tuple of the http status code and a des response
-    */
+  // Attempts to report a withdrawal charge
   def reportWithdrawalCharge(lisaManager: String, accountId: String, request: ReportWithdrawalChargeRequest)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {
@@ -417,8 +399,7 @@ class DesConnector @Inject() (
     }
   }
 
-  /** Attempts to details on a transaction from ETMP
-    */
+  // Attempts to details on a transaction from ETMP
   def getTransaction(lisaManager: String, accountId: String, transactionId: String)(implicit
     hc: HeaderCarrier
   ): Future[DesResponse] = {

--- a/test/uk/gov/hmrc/lisaapi/connectors/ConnectorSpecHelper.scala
+++ b/test/uk/gov/hmrc/lisaapi/connectors/ConnectorSpecHelper.scala
@@ -27,8 +27,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.lisaapi.helpers.BaseTestFixture
 import uk.gov.hmrc.lisaapi.utils.WireMockHelper
 
-trait ConnectorSpecHelper
-    extends BaseTestFixture with GuiceOneAppPerSuite with WireMockHelper with ScalaFutures with IntegrationPatience {
+trait ConnectorSpecHelper extends BaseTestFixture with GuiceOneAppPerSuite with WireMockHelper {
 
   def applicationBuilder(): GuiceApplicationBuilder =
     new GuiceApplicationBuilder()

--- a/test/uk/gov/hmrc/lisaapi/connectors/ConnectorSpecHelper.scala
+++ b/test/uk/gov/hmrc/lisaapi/connectors/ConnectorSpecHelper.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.lisaapi.connectors
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.Injector

--- a/test/uk/gov/hmrc/lisaapi/connectors/ConnectorSpecHelper.scala
+++ b/test/uk/gov/hmrc/lisaapi/connectors/ConnectorSpecHelper.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.lisaapi.connectors
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.Injector
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.lisaapi.helpers.BaseTestFixture
+import uk.gov.hmrc.lisaapi.utils.WireMockHelper
+
+trait ConnectorSpecHelper
+    extends BaseTestFixture with GuiceOneAppPerSuite with WireMockHelper with ScalaFutures with IntegrationPatience {
+
+  def applicationBuilder(): GuiceApplicationBuilder =
+    new GuiceApplicationBuilder()
+      .configure(
+        "microservice.services.des.protocol" -> "http",
+        "microservice.services.des.host"     -> "localhost",
+        "microservice.services.des.port"     -> server.port(),
+        "metrics.enabled"                    -> false,
+        "auditing.enabled"                   -> false
+      )
+
+  override def fakeApplication(): Application = applicationBuilder().build()
+
+  lazy val injector: Injector = app.injector
+
+  def buildResponse(returnStatus: Int, responseBody: String = ""): ResponseDefinitionBuilder = {
+    val response: ResponseDefinitionBuilder =
+      aResponse()
+        .withStatus(returnStatus)
+        .withBody(responseBody)
+
+    if (responseBody.nonEmpty) {
+      response.withHeader("Content-Type", "application/json")
+    } else {
+      response
+    }
+  }
+
+  def stubForGet(url: String, returnStatus: Int, responseBody: String = ""): StubMapping = {
+    val response = buildResponse(returnStatus, responseBody)
+    server.stubFor(
+      get(urlEqualTo(url)).willReturn(response)
+    )
+  }
+
+  def stubForPost(url: String, returnStatus: Int, responseBody: String = ""): StubMapping = {
+    val response = buildResponse(returnStatus, responseBody)
+    server.stubFor(
+      post(urlEqualTo(url)).willReturn(response)
+    )
+  }
+
+  def stubForPut(url: String, returnStatus: Int, responseBody: String = ""): StubMapping = {
+    val response = buildResponse(returnStatus, responseBody)
+    server.stubFor(
+      put(urlEqualTo(url)).willReturn(response)
+    )
+  }
+
+}

--- a/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorSpec.scala
@@ -19,10 +19,12 @@ package uk.gov.hmrc.lisaapi.connectors
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.http.Fault
 import play.api.test.Helpers.*
+import uk.gov.hmrc.http.{HeaderCarrier, RequestId}
 import uk.gov.hmrc.lisaapi.models.*
 import uk.gov.hmrc.lisaapi.models.des.*
 
 import java.time.LocalDate
+import java.util.UUID
 
 class DesConnectorSpec extends DesConnectorTestHelper {
 
@@ -238,6 +240,16 @@ class DesConnectorSpec extends DesConnectorTestHelper {
         }
       }
     }
+
+    "return a DesBadRequestResponse" when {
+      "a 400 is returned" in {
+        stubForPost(transferAccountUrl, BAD_REQUEST, "")
+        transferAccountRequest { response =>
+          response mustBe DesBadRequestResponse
+        }
+      }
+    }
+
   }
 
   "Close Lisa Account endpoint" must {
@@ -289,7 +301,7 @@ class DesConnectorSpec extends DesConnectorTestHelper {
     }
 
     "return a generic failure response" when {
-      "the DES response has no json body" in {
+      "a 200 is returned, but the DES response has no json body" in {
         stubForPut(reinstateAccountUrl, OK, "")
         reinstateAccountRequest { response =>
           response mustBe DesFailureResponse()
@@ -314,6 +326,16 @@ class DesConnectorSpec extends DesConnectorTestHelper {
         }
       }
     }
+
+    "return a DesFailureResponse" when {
+      "a 500 is returned (not 200/400/503)" in {
+        stubForPut(reinstateAccountUrl, INTERNAL_SERVER_ERROR, "")
+        reinstateAccountRequest { response =>
+          response mustBe DesFailureResponse()
+        }
+      }
+    }
+
   }
 
   "Update First Subscription date endpoint" must {
@@ -370,6 +392,20 @@ class DesConnectorSpec extends DesConnectorTestHelper {
         }
       }
     }
+
+    "return a DesTransactionExistResponse" when {
+      "a 409 response is returned with json in the correct format" in {
+        stubForPut(
+          updateFirstSubUrl,
+          CONFLICT,
+          """{"code": "x", "reason": "xx", "transactionID": "87654321"}"""
+        )
+        updateFirstSubscriptionDateRequest { response =>
+          response mustBe DesTransactionExistResponse(code = "x", reason = "xx", transactionID = "87654321")
+        }
+      }
+    }
+
   }
 
   "Report Life Event endpoint" must {
@@ -549,7 +585,7 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       "the connection fails" in {
         server.stubFor(
           post(urlEqualTo(requestBonusUrl))
-            .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
+            .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK))
         )
         requestBonusPaymentRequest { response =>
           response mustBe DesFailureResponse()
@@ -1077,6 +1113,36 @@ class DesConnectorSpec extends DesConnectorTestHelper {
           response mustBe DesBadRequestResponse
         }
       }
+    }
+  }
+
+  "correlationId" must {
+
+    "reuse the requestId given it matches the correlation id pattern, and return a valid UUID" in {
+      implicit val hc: HeaderCarrier =
+        HeaderCarrier(requestId = Some(RequestId("abcd1234-ab12-cd34-ef56")))
+
+      val result = desConnector.correlationId
+
+      result must startWith("abcd1234-ab12-cd34-ef56-")
+      UUID.fromString(result)
+    }
+
+    "make a new, valid UUID when the requestId does not match the correlation id pattern" in {
+      implicit val hc: HeaderCarrier =
+        HeaderCarrier(requestId = Some(RequestId("not-a-valid-correlation-id-pattern")))
+
+      val result = desConnector.correlationId
+
+      UUID.fromString(result)
+    }
+
+    "make a new, valid UUID when the requestId is empty" in {
+      implicit val hc: HeaderCarrier = HeaderCarrier(requestId = None)
+
+      val result = desConnector.correlationId
+
+      UUID.fromString(result)
     }
   }
 

--- a/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorSpec.scala
@@ -52,13 +52,10 @@ class DesConnectorSpec extends DesConnectorTestHelper {
     "/enterprise/financial-data/ZISA/Z123456/LISA?dateFrom=2018-01-01&dateTo=2018-01-01&onlyOpenItems=false"
 
   "Create Lisa Investor endpoint" must {
-    "return a populated CreateLisaInvestorSuccessResponse" when {
-
-      "The DES response has a json body that is in the correct format" in {
-        stubForPost(createInvestorUrl, CREATED, """{"investorID": "1234567890"}""")
-        createInvestorRequest { response =>
-          response must be(CreateLisaInvestorSuccessResponse("1234567890"))
-        }
+    "return a populated CreateLisaInvestorSuccessResponse when The DES response has a json body that is in the correct format" in {
+      stubForPost(createInvestorUrl, CREATED, """{"investorID": "1234567890"}""")
+      createInvestorRequest { response =>
+        response must be(CreateLisaInvestorSuccessResponse("1234567890"))
       }
     }
 
@@ -85,57 +82,47 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a populated CreateLisaInvestorAlreadyExistsResponse" when {
-      "the investor already exists response is returned" in {
-        val investorID = "1234567890"
-        stubForPost(createInvestorUrl, CONFLICT, s"""{"investorID": "$investorID"}""")
-        createInvestorRequest { response =>
-          response must be(CreateLisaInvestorAlreadyExistsResponse(investorID))
-        }
+    "return a populated CreateLisaInvestorAlreadyExistsResponse when the investor already exists response is returned" in {
+      val investorID = "1234567890"
+      stubForPost(createInvestorUrl, CONFLICT, s"""{"investorID": "$investorID"}""")
+      createInvestorRequest { response =>
+        response must be(CreateLisaInvestorAlreadyExistsResponse(investorID))
       }
     }
 
-    "return a specific DesFailureResponse" when {
-      "a specific failure is returned" in {
-        stubForPost(
-          createInvestorUrl,
-          FORBIDDEN,
-          """{"code": "INVESTOR_NOT_FOUND","reason": "The investor details given do not match with HMRC’s records."}"""
+    "return a specific DesFailureResponse when a specific failure is returned" in {
+      stubForPost(
+        createInvestorUrl,
+        FORBIDDEN,
+        """{"code": "INVESTOR_NOT_FOUND","reason": "The investor details given do not match with HMRC’s records."}"""
+      )
+      createInvestorRequest { response =>
+        response must be(
+          DesFailureResponse("INVESTOR_NOT_FOUND", "The investor details given do not match with HMRC’s records.")
         )
-        createInvestorRequest { response =>
-          response must be(
-            DesFailureResponse("INVESTOR_NOT_FOUND", "The investor details given do not match with HMRC’s records.")
-          )
-        }
       }
     }
 
-    "return a DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForPost(createInvestorUrl, SERVICE_UNAVAILABLE, "")
-        createInvestorRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 is returned" in {
+      stubForPost(createInvestorUrl, SERVICE_UNAVAILABLE, "")
+      createInvestorRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
-    "return a DesBadRequestResponse" when {
-      "a 400 is returned" in {
-        stubForPost(createInvestorUrl, BAD_REQUEST, "")
-        createInvestorRequest { response =>
-          response mustBe DesBadRequestResponse
-        }
+    "return a DesBadRequestResponse when a 400 is returned" in {
+      stubForPost(createInvestorUrl, BAD_REQUEST, "")
+      createInvestorRequest { response =>
+        response mustBe DesBadRequestResponse
       }
     }
   }
 
   "Create Account endpoint" must {
-    "return a populated success response" when {
-      "DES returns 201 created" in {
-        stubForPost(createAccountUrl, CREATED, "")
-        createAccountRequest { response =>
-          response mustBe DesAccountResponse("9876543210")
-        }
+    "return a populated success response when DES returns 201 created" in {
+      stubForPost(createAccountUrl, CREATED, "")
+      createAccountRequest { response =>
+        response mustBe DesAccountResponse("9876543210")
       }
     }
 
@@ -155,48 +142,41 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForPost(createAccountUrl, SERVICE_UNAVAILABLE, "")
-        createAccountRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 is returned" in {
+      stubForPost(createAccountUrl, SERVICE_UNAVAILABLE, "")
+      createAccountRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
-    "return a DesBadRequestResponse" when {
-      "a 400 is returned" in {
-        stubForPost(createAccountUrl, BAD_REQUEST, "")
-        createAccountRequest { response =>
-          response mustBe DesBadRequestResponse
-        }
+    "return a DesBadRequestResponse when a 400 is returned" in {
+      stubForPost(createAccountUrl, BAD_REQUEST, "")
+      createAccountRequest { response =>
+        response mustBe DesBadRequestResponse
       }
     }
 
-    "return a type-appropriate failure response" when {
-      "a specific failure is returned" in {
-        stubForPost(
-          createAccountUrl,
-          FORBIDDEN,
-          """{"code": "INVESTOR_NOT_FOUND", "reason": "The investorId given does not match with HMRC’s records."}"""
+    "return a type-appropriate failure response when a specific failure is returned" in {
+      stubForPost(
+        createAccountUrl,
+        FORBIDDEN,
+        """{"code": "INVESTOR_NOT_FOUND", "reason": "The investorId given does not match with HMRC’s records."}"""
+      )
+
+      createAccountRequest { response =>
+        response mustBe DesFailureResponse(
+          "INVESTOR_NOT_FOUND",
+          "The investorId given does not match with HMRC’s records."
         )
-        createAccountRequest { response =>
-          response mustBe DesFailureResponse(
-            "INVESTOR_NOT_FOUND",
-            "The investorId given does not match with HMRC’s records."
-          )
-        }
       }
     }
   }
 
   "Transfer Account endpoint" must {
-    "return a populated success response" when {
-      "DES returns 201 created" in {
-        stubForPost(transferAccountUrl, CREATED, "")
-        transferAccountRequest { response =>
-          response mustBe DesAccountResponse("9876543210")
-        }
+    "return a populated success response when DES returns 201 created" in {
+      stubForPost(transferAccountUrl, CREATED, "")
+      transferAccountRequest { response =>
+        response mustBe DesAccountResponse("9876543210")
       }
     }
 
@@ -216,142 +196,116 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a type-appropriate failure response" when {
-      "a specific failure is returned" in {
-        stubForPost(
-          transferAccountUrl,
-          FORBIDDEN,
-          """{"code": "INVESTOR_NOT_FOUND", "reason": "The investorId given does not match with HMRC’s records."}"""
+    "return a type-appropriate failure response when a specific failure is returned" in {
+      stubForPost(
+        transferAccountUrl,
+        FORBIDDEN,
+        """{"code": "INVESTOR_NOT_FOUND", "reason": "The investorId given does not match with HMRC’s records."}"""
+      )
+      transferAccountRequest { response =>
+        response mustBe DesFailureResponse(
+          "INVESTOR_NOT_FOUND",
+          "The investorId given does not match with HMRC’s records."
         )
-        transferAccountRequest { response =>
-          response mustBe DesFailureResponse(
-            "INVESTOR_NOT_FOUND",
-            "The investorId given does not match with HMRC’s records."
-          )
-        }
       }
     }
 
-    "return a DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForPost(transferAccountUrl, SERVICE_UNAVAILABLE, "")
-        transferAccountRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 is returned" in {
+      stubForPost(transferAccountUrl, SERVICE_UNAVAILABLE, "")
+      transferAccountRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
-    "return a DesBadRequestResponse" when {
-      "a 400 is returned" in {
-        stubForPost(transferAccountUrl, BAD_REQUEST, "")
-        transferAccountRequest { response =>
-          response mustBe DesBadRequestResponse
-        }
+    "return a DesBadRequestResponse when a 400 is returned" in {
+      stubForPost(transferAccountUrl, BAD_REQUEST, "")
+      transferAccountRequest { response =>
+        response mustBe DesBadRequestResponse
       }
     }
 
   }
 
   "Close Lisa Account endpoint" must {
-    "return a DesEmptySuccessResponse" when {
-      "DES returns 200 ok" in {
-        stubForPost(closeAccountUrl, OK, "")
-        closeAccountRequest { response =>
-          response mustBe DesEmptySuccessResponse
-        }
+    "return a DesEmptySuccessResponse when DES returns 200 ok" in {
+      stubForPost(closeAccountUrl, OK, "")
+      closeAccountRequest { response =>
+        response mustBe DesEmptySuccessResponse
       }
     }
 
-    "return a DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForPost(closeAccountUrl, SERVICE_UNAVAILABLE, "")
-        closeAccountRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 is returned" in {
+      stubForPost(closeAccountUrl, SERVICE_UNAVAILABLE, "")
+      closeAccountRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
-    "return a DesBadRequestResponse" when {
-      "a 400 is returned" in {
-        stubForPost(closeAccountUrl, BAD_REQUEST, "")
-        closeAccountRequest { response =>
-          response mustBe DesBadRequestResponse
-        }
+    "return a DesBadRequestResponse when a 400 is returned" in {
+      stubForPost(closeAccountUrl, BAD_REQUEST, "")
+      closeAccountRequest { response =>
+        response mustBe DesBadRequestResponse
       }
     }
 
-    "return a DesFailureResponse" when {
-      "any other response is received" in {
-        stubForPost(closeAccountUrl, GATEWAY_TIMEOUT, "")
-        closeAccountRequest { response =>
-          response mustBe DesFailureResponse()
-        }
+    "return a DesFailureResponse when any other response is received" in {
+      stubForPost(closeAccountUrl, GATEWAY_TIMEOUT, "")
+      closeAccountRequest { response =>
+        response mustBe DesFailureResponse()
       }
     }
   }
 
   "Reinstate Lisa Account endpoint" must {
-    "return a populated success response" when {
-      "DES returns 200 ok" in {
-        stubForPut(reinstateAccountUrl, OK, """{"code": "SUCCESS", "reason": "Account successfully reinstated"}""")
-        reinstateAccountRequest { response =>
-          response mustBe DesReinstateAccountSuccessResponse("SUCCESS", "Account successfully reinstated")
-        }
+    "return a populated success response when DES returns 200 ok" in {
+      stubForPut(reinstateAccountUrl, OK, """{"code": "SUCCESS", "reason": "Account successfully reinstated"}""")
+      reinstateAccountRequest { response =>
+        response mustBe DesReinstateAccountSuccessResponse("SUCCESS", "Account successfully reinstated")
       }
     }
 
-    "return a generic failure response" when {
-      "a 200 is returned, but the DES response has no json body" in {
-        stubForPut(reinstateAccountUrl, OK, "")
-        reinstateAccountRequest { response =>
-          response mustBe DesFailureResponse()
-        }
+    "return a generic failure response when a 200 is returned, but the DES response has no json body" in {
+      stubForPut(reinstateAccountUrl, OK, "")
+      reinstateAccountRequest { response =>
+        response mustBe DesFailureResponse()
       }
     }
 
-    "return a DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForPut(reinstateAccountUrl, SERVICE_UNAVAILABLE, "")
-        reinstateAccountRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 is returned" in {
+      stubForPut(reinstateAccountUrl, SERVICE_UNAVAILABLE, "")
+      reinstateAccountRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
-    "return a DesBadRequestResponse" when {
-      "a 400 is returned" in {
-        stubForPut(reinstateAccountUrl, BAD_REQUEST, "")
-        reinstateAccountRequest { response =>
-          response mustBe DesBadRequestResponse
-        }
+    "return a DesBadRequestResponse when a 400 is returned" in {
+      stubForPut(reinstateAccountUrl, BAD_REQUEST, "")
+      reinstateAccountRequest { response =>
+        response mustBe DesBadRequestResponse
       }
     }
 
-    "return a DesFailureResponse" when {
-      "a 500 is returned (not 200/400/503)" in {
-        stubForPut(reinstateAccountUrl, INTERNAL_SERVER_ERROR, "")
-        reinstateAccountRequest { response =>
-          response mustBe DesFailureResponse()
-        }
+    "return a DesFailureResponse when a 500 is returned (not 200/400/503)" in {
+      stubForPut(reinstateAccountUrl, INTERNAL_SERVER_ERROR, "")
+      reinstateAccountRequest { response =>
+        response mustBe DesFailureResponse()
       }
     }
 
   }
 
   "Update First Subscription date endpoint" must {
-    "return a populated DesUpdateSubscriptionSuccessResponse" when {
-      "the DES response has a json body that is in the correct format" in {
-        stubForPut(
-          updateFirstSubUrl,
-          OK,
-          """{"code": "INVESTOR_ACCOUNT_NOW_VOID", "reason": "Date of first Subscription updated successfully, but as a result of the date change the account has subsequently been voided"}"""
+    "return a populated DesUpdateSubscriptionSuccessResponse when the DES response has a json body that is in the correct format" in {
+      stubForPut(
+        updateFirstSubUrl,
+        OK,
+        """{"code": "INVESTOR_ACCOUNT_NOW_VOID", "reason": "Date of first Subscription updated successfully, but as a result of the date change the account has subsequently been voided"}"""
+      )
+      updateFirstSubscriptionDateRequest { response =>
+        response mustBe DesUpdateSubscriptionSuccessResponse(
+          "INVESTOR_ACCOUNT_NOW_VOID",
+          "Date of first Subscription updated successfully, but as a result of the date change the account has subsequently been voided"
         )
-        updateFirstSubscriptionDateRequest { response =>
-          response mustBe DesUpdateSubscriptionSuccessResponse(
-            "INVESTOR_ACCOUNT_NOW_VOID",
-            "Date of first Subscription updated successfully, but as a result of the date change the account has subsequently been voided"
-          )
-        }
       }
     }
 
@@ -375,55 +329,45 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a DesUnavailableResponse" when {
-      "a 503 response is returned" in {
-        stubForPut(updateFirstSubUrl, SERVICE_UNAVAILABLE, "")
-        updateFirstSubscriptionDateRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 response is returned" in {
+      stubForPut(updateFirstSubUrl, SERVICE_UNAVAILABLE, "")
+      updateFirstSubscriptionDateRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
-    "return a DesBadRequestResponse" when {
-      "a 400 response is returned" in {
-        stubForPut(updateFirstSubUrl, BAD_REQUEST, "")
-        updateFirstSubscriptionDateRequest { response =>
-          response mustBe DesBadRequestResponse
-        }
+    "return a DesBadRequestResponse when a 400 response is returned" in {
+      stubForPut(updateFirstSubUrl, BAD_REQUEST, "")
+      updateFirstSubscriptionDateRequest { response =>
+        response mustBe DesBadRequestResponse
       }
     }
 
-    "return a DesTransactionExistResponse" when {
-      "a 409 response is returned with json in the correct format" in {
-        stubForPut(
-          updateFirstSubUrl,
-          CONFLICT,
-          """{"code": "x", "reason": "xx", "transactionID": "87654321"}"""
-        )
-        updateFirstSubscriptionDateRequest { response =>
-          response mustBe DesTransactionExistResponse(code = "x", reason = "xx", transactionID = "87654321")
-        }
+    "return a DesTransactionExistResponse when a 409 response is returned with json in the correct format" in {
+      stubForPut(
+        updateFirstSubUrl,
+        CONFLICT,
+        """{"code": "x", "reason": "xx", "transactionID": "87654321"}"""
+      )
+      updateFirstSubscriptionDateRequest { response =>
+        response mustBe DesTransactionExistResponse(code = "x", reason = "xx", transactionID = "87654321")
       }
     }
 
   }
 
   "Report Life Event endpoint" must {
-    "return a populated DesSuccessResponse" when {
-      "the DES response has a json body that is in the correct format" in {
-        stubForPost(reportLifeEventUrl, CREATED, """{"lifeEventID": "87654321"}""")
-        reportLifeEventRequest { response =>
-          response mustBe DesLifeEventResponse("87654321")
-        }
+    "return a populated DesSuccessResponse when the DES response has a json body that is in the correct format" in {
+      stubForPost(reportLifeEventUrl, CREATED, """{"lifeEventID": "87654321"}""")
+      reportLifeEventRequest { response =>
+        response mustBe DesLifeEventResponse("87654321")
       }
     }
 
-    "return a DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForPost(reportLifeEventUrl, SERVICE_UNAVAILABLE, "")
-        reportLifeEventRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 is returned" in {
+      stubForPost(reportLifeEventUrl, SERVICE_UNAVAILABLE, "")
+      reportLifeEventRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
@@ -443,30 +387,26 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a populated DesFailureResponse" when {
-      "a LIFE_EVENT_INAPPROPRIATE failure is returned" in {
-        stubForPost(
-          reportLifeEventUrl,
-          FORBIDDEN,
-          """{"code": "LIFE_EVENT_INAPPROPRIATE","reason": "The life event conflicts with previous life event reported."}"""
+    "return a populated DesFailureResponse when a LIFE_EVENT_INAPPROPRIATE failure is returned" in {
+      stubForPost(
+        reportLifeEventUrl,
+        FORBIDDEN,
+        """{"code": "LIFE_EVENT_INAPPROPRIATE","reason": "The life event conflicts with previous life event reported."}"""
+      )
+      reportLifeEventRequest { response =>
+        response mustBe DesFailureResponse(
+          "LIFE_EVENT_INAPPROPRIATE",
+          "The life event conflicts with previous life event reported."
         )
-        reportLifeEventRequest { response =>
-          response mustBe DesFailureResponse(
-            "LIFE_EVENT_INAPPROPRIATE",
-            "The life event conflicts with previous life event reported."
-          )
-        }
       }
     }
   }
 
   "Retrieve Life Event endpoint" must {
-    "return a Left of DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForGet(getLifeEventUrl, SERVICE_UNAVAILABLE, "")
-        retrieveLifeEventRequest { response =>
-          response mustBe Left(DesUnavailableResponse)
-        }
+    "return a Left of DesUnavailableResponse when a 503 is returned" in {
+      stubForGet(getLifeEventUrl, SERVICE_UNAVAILABLE, "")
+      retrieveLifeEventRequest { response =>
+        response mustBe Left(DesUnavailableResponse)
       }
     }
 
@@ -498,45 +438,39 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a Right of Seq GetLifeEventItem" when {
-      "DES returns successfully" in {
-        stubForGet(
-          getLifeEventUrl,
-          OK,
-          """[{ "lifeEventId": "1234567890", "lifeEventType": "STATUTORY_SUBMISSION", "lifeEventDate": "2018-04-05" }]"""
-        )
+    "return a Right of Seq GetLifeEventItem when DES returns successfully" in {
+      stubForGet(
+        getLifeEventUrl,
+        OK,
+        """[{ "lifeEventId": "1234567890", "lifeEventType": "STATUTORY_SUBMISSION", "lifeEventDate": "2018-04-05" }]"""
+      )
 
-        retrieveLifeEventRequest { response =>
-          response mustBe Right(
-            List(
-              GetLifeEventItem(
-                lifeEventId = "1234567890",
-                eventType = "Statutory Submission",
-                eventDate = LocalDate.parse("2018-04-05")
-              )
+      retrieveLifeEventRequest { response =>
+        response mustBe Right(
+          List(
+            GetLifeEventItem(
+              lifeEventId = "1234567890",
+              eventType = "Statutory Submission",
+              eventDate = LocalDate.parse("2018-04-05")
             )
           )
-        }
+        )
       }
     }
   }
 
   "Request Bonus Payment endpoint" must {
-    "return a populated DesTransactionResponse" when {
-      "the DES response has a json body that is in the correct format" in {
-        stubForPost(requestBonusUrl, CREATED, """{"transactionID": "87654321","message": "On Time"}""")
-        requestBonusPaymentRequest { response =>
-          response mustBe DesTransactionResponse("87654321", Some("On Time"))
-        }
+    "return a populated DesTransactionResponse when the DES response has a json body that is in the correct format" in {
+      stubForPost(requestBonusUrl, CREATED, """{"transactionID": "87654321","message": "On Time"}""")
+      requestBonusPaymentRequest { response =>
+        response mustBe DesTransactionResponse("87654321", Some("On Time"))
       }
     }
 
-    "return a populated DesTransactionExistResponse" when {
-      "the DES response returns a 409 with a json body that is in the correct format" in {
-        stubForPost(requestBonusUrl, CONFLICT, """{"code": "x", "reason": "xx", "transactionID": "87654321"}""")
-        requestBonusPaymentRequest { response =>
-          response mustBe DesTransactionExistResponse(code = "x", reason = "xx", transactionID = "87654321")
-        }
+    "return a populated DesTransactionExistResponse when the DES response returns a 409 with a json body that is in the correct format" in {
+      stubForPost(requestBonusUrl, CONFLICT, """{"code": "x", "reason": "xx", "transactionID": "87654321"}""")
+      requestBonusPaymentRequest { response =>
+        response mustBe DesTransactionExistResponse(code = "x", reason = "xx", transactionID = "87654321")
       }
     }
 
@@ -556,60 +490,50 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a specific DesFailureResponse" when {
-      "a specific failure is returned" in {
-        stubForPost(
-          requestBonusUrl,
-          NOT_FOUND,
-          """{"code": "LIFE_EVENT_DOES_NOT_EXIST","reason": "The lifeEventId does not match with HMRC’s records."}"""
+    "return a specific DesFailureResponse when a specific failure is returned" in {
+      stubForPost(
+        requestBonusUrl,
+        NOT_FOUND,
+        """{"code": "LIFE_EVENT_DOES_NOT_EXIST","reason": "The lifeEventId does not match with HMRC’s records."}"""
+      )
+      requestBonusPaymentRequest { response =>
+        response mustBe DesFailureResponse(
+          "LIFE_EVENT_DOES_NOT_EXIST",
+          "The lifeEventId does not match with HMRC’s records."
         )
-        requestBonusPaymentRequest { response =>
-          response mustBe DesFailureResponse(
-            "LIFE_EVENT_DOES_NOT_EXIST",
-            "The lifeEventId does not match with HMRC’s records."
-          )
-        }
       }
     }
 
-    "return a DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForPost(requestBonusUrl, SERVICE_UNAVAILABLE, "")
-        requestBonusPaymentRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 is returned" in {
+      stubForPost(requestBonusUrl, SERVICE_UNAVAILABLE, "")
+      requestBonusPaymentRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
-    "return a DesFailureResponse" when {
-      "the connection fails" in {
-        server.stubFor(
-          post(urlEqualTo(requestBonusUrl))
-            .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK))
-        )
-        requestBonusPaymentRequest { response =>
-          response mustBe DesFailureResponse()
-        }
+    "return a DesFailureResponse when the connection fails" in {
+      server.stubFor(
+        post(urlEqualTo(requestBonusUrl))
+          .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK))
+      )
+      requestBonusPaymentRequest { response =>
+        response mustBe DesFailureResponse()
       }
     }
 
-    "return a DesBadRequestResponse" when {
-      "a 400 is returned" in {
-        stubForPost(requestBonusUrl, BAD_REQUEST, "")
-        requestBonusPaymentRequest { response =>
-          response mustBe DesBadRequestResponse
-        }
+    "return a DesBadRequestResponse when a 400 is returned" in {
+      stubForPost(requestBonusUrl, BAD_REQUEST, "")
+      requestBonusPaymentRequest { response =>
+        response mustBe DesBadRequestResponse
       }
     }
   }
 
   "Retrieve Bonus Payment endpoint" must {
-    "return a DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForGet(getBonusOrWithdrawal, SERVICE_UNAVAILABLE, "")
-        retrieveBonusPaymentRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 is returned" in {
+      stubForGet(getBonusOrWithdrawal, SERVICE_UNAVAILABLE, "")
+      retrieveBonusPaymentRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
@@ -637,34 +561,30 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a GetBonusResponse" when {
-      "DES returns successfully" in {
-        stubForGet(getBonusOrWithdrawal, OK, validBonusPaymentResponseJson)
-        retrieveBonusPaymentRequest { response =>
-          response mustBe GetBonusResponse(
-            lifeEventId = Some("1234567891"),
-            periodStartDate = LocalDate.parse("2017-04-06"),
-            periodEndDate = LocalDate.parse("2017-05-05"),
-            htbTransfer = Some(HelpToBuyTransfer(0, 10)),
-            inboundPayments = InboundPayments(Some(4000), 4000, 4000, 4000),
-            bonuses = Bonuses(1000, 1000, Some(1000), "Life Event"),
-            creationDate = LocalDate.parse("2017-05-05"),
-            paymentStatus = "Paid",
-            supersededBy = None,
-            supersede = None
-          )
-        }
+    "return a GetBonusResponse when DES returns successfully" in {
+      stubForGet(getBonusOrWithdrawal, OK, validBonusPaymentResponseJson)
+      retrieveBonusPaymentRequest { response =>
+        response mustBe GetBonusResponse(
+          lifeEventId = Some("1234567891"),
+          periodStartDate = LocalDate.parse("2017-04-06"),
+          periodEndDate = LocalDate.parse("2017-05-05"),
+          htbTransfer = Some(HelpToBuyTransfer(0, 10)),
+          inboundPayments = InboundPayments(Some(4000), 4000, 4000, 4000),
+          bonuses = Bonuses(1000, 1000, Some(1000), "Life Event"),
+          creationDate = LocalDate.parse("2017-05-05"),
+          paymentStatus = "Paid",
+          supersededBy = None,
+          supersede = None
+        )
       }
     }
   }
 
   "Retrieve Transaction endpoint" must {
-    "return a unavailable response" when {
-      "a 503 is returned" in {
-        stubForGet(getTransactionUrl, SERVICE_UNAVAILABLE, "")
-        retrieveTransactionRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a unavailable response when a 503 is returned" in {
+      stubForGet(getTransactionUrl, SERVICE_UNAVAILABLE, "")
+      retrieveTransactionRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
@@ -762,12 +682,11 @@ class DesConnectorSpec extends DesConnectorTestHelper {
   }
 
   "Retrieve Bulk Payment endpoint" must {
-    "return a unavailable response" when {
-      "a 503 is returned" in {
-        stubForGet(bulkPaymentUrl, SERVICE_UNAVAILABLE, "")
-        retrieveBulkPaymentRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+
+    "return an unavailable response when a 503 is returned" in {
+      stubForGet(bulkPaymentUrl, SERVICE_UNAVAILABLE, "")
+      retrieveBulkPaymentRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
@@ -798,10 +717,9 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a success response" when {
-      "the DES response is the appropriate json response" in {
-        val responseString =
-          """{
+    "return a success response when the DES response has the expected json response" in {
+      val responseString =
+        """{
             | "processingDate": "2017-03-07T09:30:00.000Z",
             | "idNumber": "Z5555",
             | "financialTransactions": [
@@ -825,21 +743,20 @@ class DesConnectorSpec extends DesConnectorTestHelper {
             | ]
             |}""".stripMargin
 
-        stubForGet(bulkPaymentUrl, OK, responseString)
+      stubForGet(bulkPaymentUrl, OK, responseString)
 
-        retrieveBulkPaymentRequest { response =>
-          response mustBe GetBulkPaymentSuccessResponse(
-            lisaManagerReferenceNumber = "Z5555",
-            payments = List(
-              BulkPaymentPaid(
-                paymentDate = Some(LocalDate.parse("2017-06-01")),
-                paymentReference = Some("ABC123456789"),
-                paymentAmount = 1000.00
-              ),
-              BulkPaymentPending(dueDate = Some(LocalDate.parse("2017-07-01")), paymentAmount = 1500.55)
-            )
+      retrieveBulkPaymentRequest { response =>
+        response mustBe GetBulkPaymentSuccessResponse(
+          lisaManagerReferenceNumber = "Z5555",
+          payments = List(
+            BulkPaymentPaid(
+              paymentDate = Some(LocalDate.parse("2017-06-01")),
+              paymentReference = Some("ABC123456789"),
+              paymentAmount = 1000.00
+            ),
+            BulkPaymentPending(dueDate = Some(LocalDate.parse("2017-07-01")), paymentAmount = 1500.55)
           )
-        }
+        )
       }
     }
 
@@ -879,12 +796,10 @@ class DesConnectorSpec extends DesConnectorTestHelper {
   }
 
   "Retrieve Account endpoint" must {
-    "return a unavailable response" when {
-      "a 503 is returned" in {
-        stubForGet(getAccountUrl, SERVICE_UNAVAILABLE, "")
-        retrieveAccountRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a unavailable response when a 503 is returned" in {
+      stubForGet(getAccountUrl, SERVICE_UNAVAILABLE, "")
+      retrieveAccountRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
@@ -916,10 +831,9 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a success response" when {
-      "the DES response is the appropriate json response" in {
-        val responseString =
-          """{
+    "return a success response when the DES response is the appropriate json response" in {
+      val responseString =
+        """{
             | "investorId": "1234567890",
             | "status": "OPEN",
             | "creationDate": "2016-01-01",
@@ -935,34 +849,32 @@ class DesConnectorSpec extends DesConnectorTestHelper {
             | "firstSubscriptionDate": "2016-01-06"
             |}""".stripMargin
 
-        stubForGet(getAccountUrl, OK, responseString)
+      stubForGet(getAccountUrl, OK, responseString)
 
-        retrieveAccountRequest { response =>
-          response mustBe GetLisaAccountSuccessResponse(
-            accountId = "123456",
-            investorId = "1234567890",
-            creationReason = "Reinstated",
-            firstSubscriptionDate = LocalDate.parse("2016-01-06"),
-            accountStatus = "OPEN",
-            subscriptionStatus = "AVAILABLE",
-            accountClosureReason = Some("Transferred out"),
-            closureDate = Some(LocalDate.parse("2016-05-01")),
-            transferAccount = Some(
-              GetLisaAccountTransferAccount(
-                transferredFromAccountId = "123abc789ABC34567890",
-                transferredFromLMRN = "Z123453",
-                transferInDate = LocalDate.parse("2016-03-01")
-              )
+      retrieveAccountRequest { response =>
+        response mustBe GetLisaAccountSuccessResponse(
+          accountId = "123456",
+          investorId = "1234567890",
+          creationReason = "Reinstated",
+          firstSubscriptionDate = LocalDate.parse("2016-01-06"),
+          accountStatus = "OPEN",
+          subscriptionStatus = "AVAILABLE",
+          accountClosureReason = Some("Transferred out"),
+          closureDate = Some(LocalDate.parse("2016-05-01")),
+          transferAccount = Some(
+            GetLisaAccountTransferAccount(
+              transferredFromAccountId = "123abc789ABC34567890",
+              transferredFromLMRN = "Z123453",
+              transferInDate = LocalDate.parse("2016-03-01")
             )
           )
-        }
+        )
       }
     }
 
-    "return a subscriptionStatus of AVAILABLE" when {
-      "there is no subscriptionStatus in the json response from DES" in {
-        val responseString =
-          """{
+    "return a subscriptionStatus of AVAILABLE when there is no subscriptionStatus in the json response from DES" in {
+      val responseString =
+        """{
             | "investorId": "1234567890",
             | "status": "OPEN",
             | "creationDate": "2016-01-01",
@@ -977,27 +889,26 @@ class DesConnectorSpec extends DesConnectorTestHelper {
             | "firstSubscriptionDate": "2016-01-06"
             |}""".stripMargin
 
-        stubForGet(getAccountUrl, OK, responseString)
+      stubForGet(getAccountUrl, OK, responseString)
 
-        retrieveAccountRequest { response =>
-          response mustBe GetLisaAccountSuccessResponse(
-            accountId = "123456",
-            investorId = "1234567890",
-            creationReason = "Reinstated",
-            firstSubscriptionDate = LocalDate.parse("2016-01-06"),
-            accountStatus = "OPEN",
-            subscriptionStatus = "AVAILABLE",
-            accountClosureReason = Some("Transferred out"),
-            closureDate = Some(LocalDate.parse("2016-05-01")),
-            transferAccount = Some(
-              GetLisaAccountTransferAccount(
-                transferredFromAccountId = "123abc789ABC34567890",
-                transferredFromLMRN = "Z123453",
-                transferInDate = LocalDate.parse("2016-03-01")
-              )
+      retrieveAccountRequest { response =>
+        response mustBe GetLisaAccountSuccessResponse(
+          accountId = "123456",
+          investorId = "1234567890",
+          creationReason = "Reinstated",
+          firstSubscriptionDate = LocalDate.parse("2016-01-06"),
+          accountStatus = "OPEN",
+          subscriptionStatus = "AVAILABLE",
+          accountClosureReason = Some("Transferred out"),
+          closureDate = Some(LocalDate.parse("2016-05-01")),
+          transferAccount = Some(
+            GetLisaAccountTransferAccount(
+              transferredFromAccountId = "123abc789ABC34567890",
+              transferredFromLMRN = "Z123453",
+              transferInDate = LocalDate.parse("2016-03-01")
             )
           )
-        }
+        )
       }
     }
   }
@@ -1010,12 +921,10 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a populated DesTransactionResponse" when {
-      "the DES response has a json body that is in the correct format" in {
-        stubForPost(withdrawalUrl, CREATED, """{"transactionID": "87654321","message": "On Time"}""")
-        reportWithdrawalRequest { response =>
-          response mustBe DesTransactionResponse("87654321", Some("On Time"))
-        }
+    "return a populated DesTransactionResponse when the DES response has a json body that is in the correct format" in {
+      stubForPost(withdrawalUrl, CREATED, """{"transactionID": "87654321","message": "On Time"}""")
+      reportWithdrawalRequest { response =>
+        response mustBe DesTransactionResponse("87654321", Some("On Time"))
       }
     }
 
@@ -1080,38 +989,32 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       }
     }
 
-    "return a specific DesFailureResponse" when {
-      "a specific failure is returned" in {
-        stubForPost(
-          withdrawalUrl,
-          NOT_FOUND,
-          """{"code": "LIFE_EVENT_DOES_NOT_EXIST","reason": "The lifeEventId does not match with HMRC’s records."}"""
+    "return a specific DesFailureResponse when a specific failure is returned" in {
+      stubForPost(
+        withdrawalUrl,
+        NOT_FOUND,
+        """{"code": "LIFE_EVENT_DOES_NOT_EXIST","reason": "The lifeEventId does not match with HMRC’s records."}"""
+      )
+
+      reportWithdrawalRequest { response =>
+        response mustBe DesFailureResponse(
+          "LIFE_EVENT_DOES_NOT_EXIST",
+          "The lifeEventId does not match with HMRC’s records."
         )
-
-        reportWithdrawalRequest { response =>
-          response mustBe DesFailureResponse(
-            "LIFE_EVENT_DOES_NOT_EXIST",
-            "The lifeEventId does not match with HMRC’s records."
-          )
-        }
       }
     }
 
-    "return a DesUnavailableResponse" when {
-      "a 503 is returned" in {
-        stubForPost(withdrawalUrl, SERVICE_UNAVAILABLE, "")
-        reportWithdrawalRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
+    "return a DesUnavailableResponse when a 503 is returned when a 503 is returned" in {
+      stubForPost(withdrawalUrl, SERVICE_UNAVAILABLE, "")
+      reportWithdrawalRequest { response =>
+        response mustBe DesUnavailableResponse
       }
     }
 
-    "return a DesBadRequestResponse" when {
-      "a 400 is returned" in {
-        stubForPost(withdrawalUrl, BAD_REQUEST, "")
-        reportWithdrawalRequest { response =>
-          response mustBe DesBadRequestResponse
-        }
+    "return a DesBadRequestResponse when a 400 is returned" in {
+      stubForPost(withdrawalUrl, BAD_REQUEST, "")
+      reportWithdrawalRequest { response =>
+        response mustBe DesBadRequestResponse
       }
     }
   }

--- a/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorSpec.scala
@@ -16,114 +16,68 @@
 
 package uk.gov.hmrc.lisaapi.connectors
 
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, verify, when}
-import org.scalatest.BeforeAndAfterEach
-import play.api.test.Helpers._
-import uk.gov.hmrc.http._
-import uk.gov.hmrc.http.client.RequestBuilder
-import uk.gov.hmrc.lisaapi.models._
-import uk.gov.hmrc.lisaapi.models.des._
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.http.Fault
+import play.api.test.Helpers.*
+import uk.gov.hmrc.lisaapi.models.*
+import uk.gov.hmrc.lisaapi.models.des.*
 
 import java.time.LocalDate
-import scala.concurrent.Future
 
-class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
-  lazy val mockRequestBuilder: RequestBuilder = mock[RequestBuilder]
+class DesConnectorSpec extends DesConnectorTestHelper {
 
-  override def beforeEach(): Unit = {
-    reset(mockHttp)
-    when(mockAppContext.desUrl).thenReturn("http://localhost:8883")
-    when(mockHttp.get(any())(any())).thenReturn(mockRequestBuilder)
-    when(mockHttp.post(any())(any())).thenReturn(mockRequestBuilder)
-    when(mockHttp.put(any())(any())).thenReturn(mockRequestBuilder)
-    when(mockRequestBuilder.withBody(any())(any(), any(), any())).thenReturn(mockRequestBuilder)
-    when(mockRequestBuilder.setHeader(any())).thenReturn(mockRequestBuilder)
-  }
+  val managerPath = "/lifetime-isa/manager"
+
+  private val createInvestorUrl  = s"$managerPath/Z019283/investors"
+  private val createAccountUrl   = s"$managerPath/Z019283/accounts"
+  private val transferAccountUrl = s"$managerPath/Z019283/accounts"
+  private val updateFirstSubUrl  = s"$managerPath/Z019283/accounts/123456789"
+
+  private val closeAccountUrl      = s"$managerPath/Z123456/accounts/ABC12345/close-account"
+  private val reinstateAccountUrl  = s"$managerPath/Z123456/accounts/ABC12345/reinstate"
+  private val reportLifeEventUrl   = s"$managerPath/Z123456/accounts/ABC12345/life-event"
+  private val getLifeEventUrl      = s"$managerPath/Z123456/accounts/ABC12345/life-events/1234567890"
+  private val requestBonusUrl      = s"$managerPath/Z123456/accounts/ABC12345/bonus-claim"
+  private val getBonusOrWithdrawal = s"$managerPath/Z123456/accounts/ABC12345/transaction/123456"
+
+  private val getTransactionUrl =
+    s"$managerPath/Z123456/accounts/ABC12345/transaction/123456/bonusChargeDetails"
+
+  private val withdrawalUrl = s"$managerPath/Z123456/accounts/ABC12345/withdrawal"
+  private val getAccountUrl = s"$managerPath/Z123456/accounts/123456"
+
+  private val bulkPaymentUrl =
+    "/enterprise/financial-data/ZISA/Z123456/LISA?dateFrom=2018-01-01&dateTo=2018-01-01&onlyOpenItems=false"
 
   "Create Lisa Investor endpoint" must {
     "return a populated CreateLisaInvestorSuccessResponse" when {
+
       "The DES response has a json body that is in the correct format" in {
-
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                s"""{"investorID": "1234567890"}""",
-                responseHeader
-              )
-            )
-          )
-        doCreateInvestorRequest { response =>
-          response must be(
-            CreateLisaInvestorSuccessResponse("1234567890")
-          )
-        }
-      }
-
-      "The DES response has a correct JSON body and multiple types" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                s"""{"investorID": "1234567890"}""",
-                Map("Content-Type" -> List("test", "application/json"))
-              )
-            )
-          )
-        doCreateInvestorRequest { response =>
-          response must be(
-            CreateLisaInvestorSuccessResponse("1234567890")
-          )
+        stubForPost(createInvestorUrl, CREATED, """{"investorID": "1234567890"}""")
+        createInvestorRequest { response =>
+          response must be(CreateLisaInvestorSuccessResponse("1234567890"))
         }
       }
     }
 
     "return the default DesFailureResponse" when {
       "the DES response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                ""
-              )
-            )
-          )
-        doCreateInvestorRequest { response =>
+        stubForPost(createInvestorUrl, OK, "")
+        createInvestorRequest { response =>
           response must be(DesFailureResponse())
         }
       }
 
       "the DES response has a json body that is in an incorrect format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                """[1,2,3]"""
-              )
-            )
-          )
-        doCreateInvestorRequest { response =>
+        stubForPost(createInvestorUrl, OK, """[1,2,3]""")
+        createInvestorRequest { response =>
           response must be(DesFailureResponse())
         }
       }
 
       "a 409 is returned with JSON that cannot be parsed as expected response" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CONFLICT,
-                """{"unexpectedField": "value", "notInvestorID": "123"}""",
-                responseHeader
-              )
-            )
-          )
-        doCreateInvestorRequest { response =>
+        stubForPost(createInvestorUrl, CONFLICT, """{"unexpectedField": "value", "notInvestorID": "123"}""")
+        createInvestorRequest { response =>
           response must be(DesFailureResponse())
         }
       }
@@ -132,17 +86,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
     "return a populated CreateLisaInvestorAlreadyExistsResponse" when {
       "the investor already exists response is returned" in {
         val investorID = "1234567890"
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CONFLICT,
-                s"""{"investorID": "$investorID"}""",
-                responseHeader
-              )
-            )
-          )
-        doCreateInvestorRequest { response =>
+        stubForPost(createInvestorUrl, CONFLICT, s"""{"investorID": "$investorID"}""")
+        createInvestorRequest { response =>
           response must be(CreateLisaInvestorAlreadyExistsResponse(investorID))
         }
       }
@@ -150,17 +95,12 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a specific DesFailureResponse" when {
       "a specific failure is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                FORBIDDEN,
-                s"""{"code": "INVESTOR_NOT_FOUND","reason": "The investor details given do not match with HMRC’s records."}""",
-                responseHeader
-              )
-            )
-          )
-        doCreateInvestorRequest { response =>
+        stubForPost(
+          createInvestorUrl,
+          FORBIDDEN,
+          """{"code": "INVESTOR_NOT_FOUND","reason": "The investor details given do not match with HMRC’s records."}"""
+        )
+        createInvestorRequest { response =>
           response must be(
             DesFailureResponse("INVESTOR_NOT_FOUND", "The investor details given do not match with HMRC’s records.")
           )
@@ -170,34 +110,17 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a DesUnavailableResponse" when {
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-        doCreateInvestorRequest { response =>
+        stubForPost(createInvestorUrl, SERVICE_UNAVAILABLE, "")
+        createInvestorRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
-
     }
 
     "return a DesBadRequestResponse" when {
       "a 400 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                BAD_REQUEST,
-                ""
-              )
-            )
-          )
-        doCreateInvestorRequest { response =>
+        stubForPost(createInvestorUrl, BAD_REQUEST, "")
+        createInvestorRequest { response =>
           response mustBe DesBadRequestResponse
         }
       }
@@ -207,16 +130,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
   "Create Account endpoint" must {
     "return a populated success response" when {
       "DES returns 201 created" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                ""
-              )
-            )
-          )
-        doCreateAccountRequest { response =>
+        stubForPost(createAccountUrl, CREATED, "")
+        createAccountRequest { response =>
           response mustBe DesAccountResponse("9876543210")
         }
       }
@@ -224,70 +139,33 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a generic failure response" when {
       "the DES response is not 201 created and has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                ""
-              )
-            )
-          )
-        doCreateAccountRequest { response =>
+        stubForPost(createAccountUrl, OK, "")
+        createAccountRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
 
       "the DES response is not 201 created and has a json body that is not in the correct format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                s"""{"problem": "service unavailable"}""",
-                responseHeader
-              )
-            )
-          )
-        doCreateAccountRequest { response =>
+        stubForPost(createAccountUrl, GATEWAY_TIMEOUT, """{"problem": "service unavailable"}""")
+        createAccountRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
-
     }
 
     "return a DesUnavailableResponse" when {
-
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-
-        doCreateAccountRequest { response =>
+        stubForPost(createAccountUrl, SERVICE_UNAVAILABLE, "")
+        createAccountRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
-
     }
 
     "return a DesBadRequestResponse" when {
       "a 400 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                BAD_REQUEST,
-                ""
-              )
-            )
-          )
-        doCreateAccountRequest { response =>
+        stubForPost(createAccountUrl, BAD_REQUEST, "")
+        createAccountRequest { response =>
           response mustBe DesBadRequestResponse
         }
       }
@@ -295,17 +173,12 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a type-appropriate failure response" when {
       "a specific failure is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                FORBIDDEN,
-                s"""{"code": "INVESTOR_NOT_FOUND", "reason": "The investorId given does not match with HMRC’s records."}""",
-                responseHeader
-              )
-            )
-          )
-        doCreateAccountRequest { response =>
+        stubForPost(
+          createAccountUrl,
+          FORBIDDEN,
+          """{"code": "INVESTOR_NOT_FOUND", "reason": "The investorId given does not match with HMRC’s records."}"""
+        )
+        createAccountRequest { response =>
           response mustBe DesFailureResponse(
             "INVESTOR_NOT_FOUND",
             "The investorId given does not match with HMRC’s records."
@@ -318,70 +191,37 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
   "Transfer Account endpoint" must {
     "return a populated success response" when {
       "DES returns 201 created" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                ""
-              )
-            )
-          )
-        doTransferAccountRequest { response =>
+        stubForPost(transferAccountUrl, CREATED, "")
+        transferAccountRequest { response =>
           response mustBe DesAccountResponse("9876543210")
         }
       }
-
     }
 
     "return a generic failure response" when {
       "the DES response is not 201 created and has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                ""
-              )
-            )
-          )
-        doTransferAccountRequest { response =>
+        stubForPost(transferAccountUrl, OK, "")
+        transferAccountRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
 
       "the DES response is not 201 created and has a json body that is not in the correct format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                s"""{"problem": "service unavailable"}""",
-                responseHeader
-              )
-            )
-          )
-
-        doTransferAccountRequest { response =>
+        stubForPost(transferAccountUrl, GATEWAY_TIMEOUT, """{"problem": "service unavailable"}""")
+        transferAccountRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
-
     }
 
     "return a type-appropriate failure response" when {
       "a specific failure is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                FORBIDDEN,
-                s"""{"code": "INVESTOR_NOT_FOUND", "reason": "The investorId given does not match with HMRC’s records."}""",
-                responseHeader
-              )
-            )
-          )
-        doTransferAccountRequest { response =>
+        stubForPost(
+          transferAccountUrl,
+          FORBIDDEN,
+          """{"code": "INVESTOR_NOT_FOUND", "reason": "The investorId given does not match with HMRC’s records."}"""
+        )
+        transferAccountRequest { response =>
           response mustBe DesFailureResponse(
             "INVESTOR_NOT_FOUND",
             "The investorId given does not match with HMRC’s records."
@@ -392,16 +232,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a DesUnavailableResponse" when {
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-        doTransferAccountRequest { response =>
+        stubForPost(transferAccountUrl, SERVICE_UNAVAILABLE, "")
+        transferAccountRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
@@ -411,10 +243,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
   "Close Lisa Account endpoint" must {
     "return a DesEmptySuccessResponse" when {
       "DES returns 200 ok" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(Future.successful(HttpResponse(OK, "")))
-
-        doCloseAccountRequest { response =>
+        stubForPost(closeAccountUrl, OK, "")
+        closeAccountRequest { response =>
           response mustBe DesEmptySuccessResponse
         }
       }
@@ -422,16 +252,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a DesUnavailableResponse" when {
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-        doCloseAccountRequest { response =>
+        stubForPost(closeAccountUrl, SERVICE_UNAVAILABLE, "")
+        closeAccountRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
@@ -439,16 +261,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a DesBadRequestResponse" when {
       "a 400 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                BAD_REQUEST,
-                ""
-              )
-            )
-          )
-        doCloseAccountRequest { response =>
+        stubForPost(closeAccountUrl, BAD_REQUEST, "")
+        closeAccountRequest { response =>
           response mustBe DesBadRequestResponse
         }
       }
@@ -456,40 +270,19 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a DesFailureResponse" when {
       "any other response is received" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                ""
-              )
-            )
-          )
-        doCloseAccountRequest { response =>
+        stubForPost(closeAccountUrl, GATEWAY_TIMEOUT, "")
+        closeAccountRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
-
     }
-
   }
 
   "Reinstate Lisa Account endpoint" must {
-
     "return a populated success response" when {
       "DES returns 200 ok" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                s"""{"code": "SUCCESS", "reason": "Account successfully reinstated"}""",
-                responseHeader
-              )
-            )
-          )
-
-        doReinstateAccountRequest { response =>
+        stubForPut(reinstateAccountUrl, OK, """{"code": "SUCCESS", "reason": "Account successfully reinstated"}""")
+        reinstateAccountRequest { response =>
           response mustBe DesReinstateAccountSuccessResponse("SUCCESS", "Account successfully reinstated")
         }
       }
@@ -497,17 +290,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a generic failure response" when {
       "the DES response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                ""
-              )
-            )
-          )
-
-        doReinstateAccountRequest { response =>
+        stubForPut(reinstateAccountUrl, OK, "")
+        reinstateAccountRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
@@ -515,17 +299,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a DesUnavailableResponse" when {
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-
-        doReinstateAccountRequest { response =>
+        stubForPut(reinstateAccountUrl, SERVICE_UNAVAILABLE, "")
+        reinstateAccountRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
@@ -533,16 +308,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a DesBadRequestResponse" when {
       "a 400 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                BAD_REQUEST,
-                ""
-              )
-            )
-          )
-        doReinstateAccountRequest { response =>
+        stubForPut(reinstateAccountUrl, BAD_REQUEST, "")
+        reinstateAccountRequest { response =>
           response mustBe DesBadRequestResponse
         }
       }
@@ -552,17 +319,11 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
   "Update First Subscription date endpoint" must {
     "return a populated DesUpdateSubscriptionSuccessResponse" when {
       "the DES response has a json body that is in the correct format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                s"""{"code": "INVESTOR_ACCOUNT_NOW_VOID", "reason": "Date of first Subscription updated successfully, but as a result of the date change the account has subsequently been voided"}""",
-                responseHeader
-              )
-            )
-          )
-
+        stubForPut(
+          updateFirstSubUrl,
+          OK,
+          """{"code": "INVESTOR_ACCOUNT_NOW_VOID", "reason": "Date of first Subscription updated successfully, but as a result of the date change the account has subsequently been voided"}"""
+        )
         updateFirstSubscriptionDateRequest { response =>
           response mustBe DesUpdateSubscriptionSuccessResponse(
             "INVESTOR_ACCOUNT_NOW_VOID",
@@ -573,76 +334,40 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
     }
 
     "return a failure response" when {
-
       "the DES response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                ""
-              )
-            )
-          )
+        stubForPut(updateFirstSubUrl, OK, "")
+        updateFirstSubscriptionDateRequest { response =>
+          response mustBe DesFailureResponse()
+        }
+      }
 
+      "status is 201 and json is invalid" in {
+        stubForPut(
+          updateFirstSubUrl,
+          CREATED,
+          """{"code": "UPDATED_AND_ACCOUNT_VOIDED", "message": "LISA Account firstSubscriptionDate has been updated successfully"}"""
+        )
         updateFirstSubscriptionDateRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
     }
 
-    "status is 201 and json is invalid" in {
-      when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-        .thenReturn(
-          Future.successful(
-            HttpResponse(
-              CREATED,
-              s"""{"code": "UPDATED_AND_ACCOUNT_VOIDED", "message": "LISA Account firstSubscriptionDate has been updated successfully"}""",
-              responseHeader
-            )
-          )
-        )
-
-      updateFirstSubscriptionDateRequest { response =>
-        response mustBe DesFailureResponse()
+    "return a DesUnavailableResponse" when {
+      "a 503 response is returned" in {
+        stubForPut(updateFirstSubUrl, SERVICE_UNAVAILABLE, "")
+        updateFirstSubscriptionDateRequest { response =>
+          response mustBe DesUnavailableResponse
+        }
       }
     }
 
-  }
-
-  "return a DesUnavailableResponse" when {
-
-    "a 503 response is returned" in {
-      when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-        .thenReturn(
-          Future.successful(
-            HttpResponse(
-              SERVICE_UNAVAILABLE,
-              ""
-            )
-          )
-        )
-
-      updateFirstSubscriptionDateRequest { response =>
-        response mustBe DesUnavailableResponse
-      }
-    }
-
-  }
-
-  "return a DesBadRequestResponse" when {
-    "a 400 response is returned" in {
-      when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-        .thenReturn(
-          Future.successful(
-            HttpResponse(
-              BAD_REQUEST,
-              ""
-            )
-          )
-        )
-      updateFirstSubscriptionDateRequest { response =>
-        response mustBe DesBadRequestResponse
+    "return a DesBadRequestResponse" when {
+      "a 400 response is returned" in {
+        stubForPut(updateFirstSubUrl, BAD_REQUEST, "")
+        updateFirstSubscriptionDateRequest { response =>
+          response mustBe DesBadRequestResponse
+        }
       }
     }
   }
@@ -650,204 +375,102 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
   "Report Life Event endpoint" must {
     "return a populated DesSuccessResponse" when {
       "the DES response has a json body that is in the correct format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                s"""{"lifeEventID": "87654321"}""",
-                responseHeader
-              )
-            )
-          )
-        doReportLifeEventRequest { response =>
+        stubForPost(reportLifeEventUrl, CREATED, """{"lifeEventID": "87654321"}""")
+        reportLifeEventRequest { response =>
           response mustBe DesLifeEventResponse("87654321")
         }
       }
-
     }
 
     "return a DesUnavailableResponse" when {
-
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-
-        doReportLifeEventRequest { response =>
+        stubForPost(reportLifeEventUrl, SERVICE_UNAVAILABLE, "")
+        reportLifeEventRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
-
     }
 
     "return a generic DesFailureResponse" when {
-
       "the response json is invalid" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                s"""{"lifeEvent": "87654321"}""",
-                responseHeader
-              )
-            )
-          )
-
-        doReportLifeEventRequest { response =>
+        stubForPost(reportLifeEventUrl, CREATED, """{"lifeEvent": "87654321"}""")
+        reportLifeEventRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
 
       "the response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                ""
-              )
-            )
-          )
-
-        doReportLifeEventRequest { response =>
+        stubForPost(reportLifeEventUrl, CREATED, "")
+        reportLifeEventRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
-
     }
 
     "return a populated DesFailureResponse" when {
-
       "a LIFE_EVENT_INAPPROPRIATE failure is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                FORBIDDEN,
-                s"""{"code": "LIFE_EVENT_INAPPROPRIATE","reason": "The life event conflicts with previous life event reported."}""",
-                responseHeader
-              )
-            )
-          )
-
-        doReportLifeEventRequest { response =>
+        stubForPost(
+          reportLifeEventUrl,
+          FORBIDDEN,
+          """{"code": "LIFE_EVENT_INAPPROPRIATE","reason": "The life event conflicts with previous life event reported."}"""
+        )
+        reportLifeEventRequest { response =>
           response mustBe DesFailureResponse(
             "LIFE_EVENT_INAPPROPRIATE",
             "The life event conflicts with previous life event reported."
           )
         }
       }
-
     }
-
   }
 
   "Retrieve Life Event endpoint" must {
-
     "return a Left of DesUnavailableResponse" when {
-
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-
-        doRetrieveLifeEventRequest { response =>
+        stubForGet(getLifeEventUrl, SERVICE_UNAVAILABLE, "")
+        retrieveLifeEventRequest { response =>
           response mustBe Left(DesUnavailableResponse)
         }
       }
-
     }
 
     "return a Left of DesFailureResponse" when {
-
       "a specific failure is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CONFLICT,
-                """{
-                  | "code": "ERROR_CODE",
-                  | "reason" : "ERROR MESSAGE"
-                  }""".stripMargin
-              )
-            )
-          )
+        stubForGet(
+          getLifeEventUrl,
+          CONFLICT,
+          """{ "code": "ERROR_CODE", "reason" : "ERROR MESSAGE" }""".stripMargin
+        )
 
-        doRetrieveLifeEventRequest { response =>
+        retrieveLifeEventRequest { response =>
           response mustBe Left(DesFailureResponse("ERROR_CODE", "ERROR MESSAGE"))
         }
       }
 
       "the response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                INTERNAL_SERVER_ERROR,
-                ""
-              )
-            )
-          )
-
-        doRetrieveLifeEventRequest { response =>
+        stubForGet(getLifeEventUrl, OK, "")
+        retrieveLifeEventRequest { response =>
           response mustBe Left(DesFailureResponse())
         }
       }
 
       "the response is badly formed" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                INTERNAL_SERVER_ERROR,
-                """{"test": "test"}""",
-                responseHeader
-              )
-            )
-          )
-
-        doRetrieveLifeEventRequest { response =>
+        stubForGet(getLifeEventUrl, OK, """{"test": "test"}""")
+        retrieveLifeEventRequest { response =>
           response mustBe Left(DesFailureResponse())
         }
       }
-
     }
 
     "return a Right of Seq GetLifeEventItem" when {
-
       "DES returns successfully" in {
+        stubForGet(
+          getLifeEventUrl,
+          OK,
+          """[{ "lifeEventId": "1234567890", "lifeEventType": "STATUTORY_SUBMISSION", "lifeEventDate": "2018-04-05" }]"""
+        )
 
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                """[{
-                  "lifeEventId": "1234567890",
-                  "lifeEventType": "STATUTORY_SUBMISSION",
-                  "lifeEventDate": "2018-04-05"
-                  }]
-                """
-              )
-            )
-          )
-
-        doRetrieveLifeEventRequest { response =>
+        retrieveLifeEventRequest { response =>
           response mustBe Right(
             List(
               GetLifeEventItem(
@@ -858,29 +481,15 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
             )
           )
         }
-
       }
-
     }
-
   }
 
   "Request Bonus Payment endpoint" must {
-
     "return a populated DesTransactionResponse" when {
       "the DES response has a json body that is in the correct format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                s"""{"transactionID": "87654321","message": "On Time"}""",
-                responseHeader
-              )
-            )
-          )
-
-        doRequestBonusPaymentRequest { response =>
+        stubForPost(requestBonusUrl, CREATED, """{"transactionID": "87654321","message": "On Time"}""")
+        requestBonusPaymentRequest { response =>
           response mustBe DesTransactionResponse("87654321", Some("On Time"))
         }
       }
@@ -888,149 +497,70 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a populated DesTransactionExistResponse" when {
       "the DES response returns a 409 with a json body that is in the correct format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CONFLICT,
-                s"""{"code": "x", "reason": "xx", "transactionID": "87654321"}""",
-                responseHeader
-              )
-            )
-          )
-
-        doRequestBonusPaymentRequest { response =>
+        stubForPost(requestBonusUrl, CONFLICT, """{"code": "x", "reason": "xx", "transactionID": "87654321"}""")
+        requestBonusPaymentRequest { response =>
           response mustBe DesTransactionExistResponse(code = "x", reason = "xx", transactionID = "87654321")
         }
       }
     }
 
     "return the default DesFailureResponse" when {
-
       "the DES response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                ""
-              )
-            )
-          )
-
-        doRequestBonusPaymentRequest { response =>
+        stubForPost(requestBonusUrl, OK, "")
+        requestBonusPaymentRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
 
       "the DES response has a json body that is in an incorrect format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                """[1,2,3]"""
-              )
-            )
-          )
-
-        doRequestBonusPaymentRequest { response =>
+        stubForPost(requestBonusUrl, CREATED, """[1,2,3]""")
+        requestBonusPaymentRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
-
     }
 
     "return a specific DesFailureResponse" when {
-
       "a specific failure is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                NOT_FOUND,
-                s"""{"code": "LIFE_EVENT_DOES_NOT_EXIST","reason": "The lifeEventId does not match with HMRC’s records."}""",
-                responseHeader
-              )
-            )
-          )
-
-        doRequestBonusPaymentRequest { response =>
+        stubForPost(
+          requestBonusUrl,
+          NOT_FOUND,
+          """{"code": "LIFE_EVENT_DOES_NOT_EXIST","reason": "The lifeEventId does not match with HMRC’s records."}"""
+        )
+        requestBonusPaymentRequest { response =>
           response mustBe DesFailureResponse(
             "LIFE_EVENT_DOES_NOT_EXIST",
             "The lifeEventId does not match with HMRC’s records."
           )
         }
       }
-
     }
 
     "return a DesUnavailableResponse" when {
-
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-
-        doRequestBonusPaymentRequest { response =>
+        stubForPost(requestBonusUrl, SERVICE_UNAVAILABLE, "")
+        requestBonusPaymentRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
-
     }
 
     "return a DesFailureResponse" when {
-
-      "a gateway timeout is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.failed(
-              UpstreamErrorResponse("Timeout", GATEWAY_TIMEOUT, GATEWAY_TIMEOUT)
-            )
-          )
-
-        doRequestBonusPaymentRequest { response =>
-          response mustBe DesFailureResponse("Timeout", "Timeout")
+      "the connection fails" in {
+        server.stubFor(
+          post(urlEqualTo(requestBonusUrl))
+            .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
+        )
+        requestBonusPaymentRequest { response =>
+          response mustBe DesFailureResponse()
         }
       }
-
-    }
-
-    "return a DesUnavailableResponse" when {
-
-      "a 499 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.failed(
-              UpstreamErrorResponse("CLIENT CLOSED REQUEST", 499, 499)
-            )
-          )
-
-        doRequestBonusPaymentRequest { response =>
-          response mustBe DesUnavailableResponse
-        }
-      }
-
     }
 
     "return a DesBadRequestResponse" when {
       "a 400 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                BAD_REQUEST,
-                ""
-              )
-            )
-          )
-        doRequestBonusPaymentRequest { response =>
+        stubForPost(requestBonusUrl, BAD_REQUEST, "")
+        requestBonusPaymentRequest { response =>
           response mustBe DesBadRequestResponse
         }
       }
@@ -1040,78 +570,41 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
   "Retrieve Bonus Payment endpoint" must {
     "return a DesUnavailableResponse" when {
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-        doRetrieveBonusPaymentRequest { response =>
+        stubForGet(getBonusOrWithdrawal, SERVICE_UNAVAILABLE, "")
+        retrieveBonusPaymentRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
-
     }
 
     "return a DesFailureResponse" when {
-
       "a specific failure is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CONFLICT,
-                """{
-                  | "code": "ERROR_CODE",
-                  | "reason" : "ERROR MESSAGE"
-                  }""".stripMargin,
-                responseHeader
-              )
-            )
-          )
+        stubForGet(
+          getBonusOrWithdrawal,
+          CONFLICT,
+          """{
+            | "code": "ERROR_CODE",
+            | "reason" : "ERROR MESSAGE"
+            |}""".stripMargin
+        )
 
-        doRetrieveBonusPaymentRequest { response =>
+        retrieveBonusPaymentRequest { response =>
           response mustBe DesFailureResponse("ERROR_CODE", "ERROR MESSAGE")
         }
       }
 
       "the response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                INTERNAL_SERVER_ERROR,
-                ""
-              )
-            )
-          )
-
-        doRetrieveBonusPaymentRequest { response =>
+        stubForGet(getBonusOrWithdrawal, OK, "")
+        retrieveBonusPaymentRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
-
     }
 
     "return a GetBonusResponse" when {
-
       "DES returns successfully" in {
-
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                validBonusPaymentResponseJson,
-                responseHeader
-              )
-            )
-          )
-
-        doRetrieveBonusPaymentRequest { response =>
+        stubForGet(getBonusOrWithdrawal, OK, validBonusPaymentResponseJson)
+        retrieveBonusPaymentRequest { response =>
           response mustBe GetBonusResponse(
             lifeEventId = Some("1234567891"),
             periodStartDate = LocalDate.parse("2017-04-06"),
@@ -1125,28 +618,15 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
             supersede = None
           )
         }
-
       }
-
     }
-
   }
 
   "Retrieve Transaction endpoint" must {
-
     "return a unavailable response" when {
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-
-        doRetrieveTransactionRequest { response =>
+        stubForGet(getTransactionUrl, SERVICE_UNAVAILABLE, "")
+        retrieveTransactionRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
@@ -1154,54 +634,31 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a failure response" when {
       "the DES response is a failure response" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                """{
-                  | "code": "ERROR_CODE",
-                  | "reason" : "ERROR MESSAGE"
-                  }""".stripMargin,
-                responseHeader
-              )
-            )
-          )
+        stubForGet(
+          getTransactionUrl,
+          OK,
+          """{ "code": "ERROR_CODE", "reason" : "ERROR MESSAGE" }""".stripMargin
+        )
 
-        doRetrieveTransactionRequest { response =>
+        retrieveTransactionRequest { response =>
           response mustBe DesFailureResponse("ERROR_CODE", "ERROR MESSAGE")
         }
       }
-      "the DES response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                ""
-              )
-            )
-          )
 
-        doRetrieveTransactionRequest { response =>
+      "the DES response has no json body" in {
+        stubForGet(getTransactionUrl, OK, "")
+        retrieveTransactionRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
-      "the DES response is invalid" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                """{
-                  | "status": "Due"
-                  }""".stripMargin,
-                responseHeader
-              )
-            )
-          )
 
-        doRetrieveTransactionRequest { response =>
+      "the DES response is invalid" in {
+        stubForGet(
+          getTransactionUrl,
+          OK,
+          """{  "status": "Due" }""".stripMargin
+        )
+        retrieveTransactionRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
@@ -1209,23 +666,18 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a success response" when {
       "the DES response is a valid collected Pending transaction" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                """{
-                  |    "paymentStatus": "PENDING",
-                  |    "paymentDate": "2000-01-01",
-                  |    "paymentReference": "002630000994",
-                  |    "paymentAmount": 2.00
-                  |}""".stripMargin,
-                responseHeader
-              )
-            )
-          )
+        stubForGet(
+          getTransactionUrl,
+          OK,
+          """{
+            | "paymentStatus": "PENDING",
+            | "paymentDate": "2000-01-01",
+            | "paymentReference": "002630000994",
+            | "paymentAmount": 2.00
+            |}""".stripMargin
+        )
 
-        doRetrieveTransactionRequest { response =>
+        retrieveTransactionRequest { response =>
           response mustBe DesGetTransactionPending(
             paymentDueDate = LocalDate.parse("2000-01-01"),
             paymentReference = Some("002630000994"),
@@ -1233,22 +685,15 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
           )
         }
       }
-      "the DES response is a valid paid Pending transaction" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                """{
-                  |    "paymentStatus": "PENDING",
-                  |    "paymentDate": "2000-01-01"
-                  |}""".stripMargin,
-                responseHeader
-              )
-            )
-          )
 
-        doRetrieveTransactionRequest { response =>
+      "the DES response is a valid paid Pending transaction" in {
+        stubForGet(
+          getTransactionUrl,
+          OK,
+          """{ "paymentStatus": "PENDING", "paymentDate": "2000-01-01" }""".stripMargin
+        )
+
+        retrieveTransactionRequest { response =>
           response mustBe DesGetTransactionPending(
             paymentDueDate = LocalDate.parse("2000-01-01"),
             paymentReference = None,
@@ -1256,24 +701,20 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
           )
         }
       }
-      "the DES response is a valid Paid transaction" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                """{
-                  |    "paymentStatus": "PAID",
-                  |    "paymentDate": "2000-01-01",
-                  |    "paymentReference": "002630000993",
-                  |    "paymentAmount": 1.00
-                  |}""".stripMargin,
-                responseHeader
-              )
-            )
-          )
 
-        doRetrieveTransactionRequest { response =>
+      "the DES response is a valid Paid transaction" in {
+        stubForGet(
+          getTransactionUrl,
+          OK,
+          """{
+            | "paymentStatus": "PAID",
+            | "paymentDate": "2000-01-01",
+            | "paymentReference": "002630000993",
+            | "paymentAmount": 1.00
+            |}""".stripMargin
+        )
+
+        retrieveTransactionRequest { response =>
           response mustBe DesGetTransactionPaid(
             paymentDate = LocalDate.parse("2000-01-01"),
             paymentReference = "002630000993",
@@ -1282,24 +723,13 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
         }
       }
     }
-
   }
 
   "Retrieve Bulk Payment endpoint" must {
-
     "return a unavailable response" when {
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-
-        doRetrieveBulkPaymentRequest { response =>
+        stubForGet(bulkPaymentUrl, SERVICE_UNAVAILABLE, "")
+        retrieveBulkPaymentRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
@@ -1307,53 +737,26 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a failure response" when {
       "the DES response is a failure response" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                """{
-                  | "code": "ERROR_CODE",
-                  | "reason" : "ERROR MESSAGE"
-                  }""".stripMargin,
-                responseHeader
-              )
-            )
-          )
-
-        doRetrieveBulkPaymentRequest { response =>
+        stubForGet(
+          bulkPaymentUrl,
+          OK,
+          """{ "code": "ERROR_CODE",  "reason" : "ERROR MESSAGE" }""".stripMargin
+        )
+        retrieveBulkPaymentRequest { response =>
           response mustBe DesFailureResponse("ERROR_CODE", "ERROR MESSAGE")
         }
       }
-      "the DES response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                ""
-              )
-            )
-          )
 
-        doRetrieveBulkPaymentRequest { response =>
+      "the DES response has no json body" in {
+        stubForGet(bulkPaymentUrl, OK, "")
+        retrieveBulkPaymentRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
+
       "the DES response is missing a processingDate" in {
-        val responseString = "{}"
-
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                responseString
-              )
-            )
-          )
-
-        doRetrieveBulkPaymentRequest { response =>
+        stubForGet(bulkPaymentUrl, OK, "{}")
+        retrieveBulkPaymentRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
@@ -1363,41 +766,32 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
       "the DES response is the appropriate json response" in {
         val responseString =
           """{
-            |    "processingDate": "2017-03-07T09:30:00.000Z",
-            |    "idNumber": "Z5555",
-            |    "financialTransactions": [
-            |      {
-            |        "clearedAmount": -1000,
-            |        "items": [
-            |          {
-            |            "clearingSAPDocument": "ABC123456789",
-            |            "clearingDate": "2017-06-01"
-            |          }
-            |        ]
-            |      },
-            |      {
-            |        "outstandingAmount": -1500.55,
-            |        "items": [
-            |          {
-            |            "dueDate": "2017-07-01"
-            |          }
-            |        ]
-            |      }
-            |    ]
+            | "processingDate": "2017-03-07T09:30:00.000Z",
+            | "idNumber": "Z5555",
+            | "financialTransactions": [
+            |   {
+            |     "clearedAmount": -1000,
+            |     "items": [
+            |       {
+            |         "clearingSAPDocument": "ABC123456789",
+            |         "clearingDate": "2017-06-01"
+            |       }
+            |     ]
+            |   },
+            |   {
+            |     "outstandingAmount": -1500.55,
+            |     "items": [
+            |       {
+            |         "dueDate": "2017-07-01"
+            |       }
+            |     ]
+            |   }
+            | ]
             |}""".stripMargin
 
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                responseString,
-                responseHeader
-              )
-            )
-          )
+        stubForGet(bulkPaymentUrl, OK, responseString)
 
-        doRetrieveBulkPaymentRequest { response =>
+        retrieveBulkPaymentRequest { response =>
           response mustBe GetBulkPaymentSuccessResponse(
             lisaManagerReferenceNumber = "Z5555",
             payments = List(
@@ -1416,88 +810,43 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
     "return a not found response" when {
       "the DES response has no financial transactions field" in {
         val responseString =
-          """{
-            | "processingDate": "2017-03-07T09:30:00.000Z",
-            | "idNumber": "Z1234"
-            |}""".stripMargin
+          """{ "processingDate": "2017-03-07T09:30:00.000Z", "idNumber": "Z1234" }""".stripMargin
 
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                responseString,
-                responseHeader
-              )
-            )
-          )
-
-        doRetrieveBulkPaymentRequest { response =>
+        stubForGet(bulkPaymentUrl, OK, responseString)
+        retrieveBulkPaymentRequest { response =>
           response mustBe GetBulkPaymentNotFoundResponse
         }
       }
+
       "the DES response has no id number field" in {
         val responseString =
-          """{
-            | "processingDate": "2017-03-07T09:30:00.000Z",
-            | "financialTransactions": []
-            |}""".stripMargin
+          """{ "processingDate": "2017-03-07T09:30:00.000Z", "financialTransactions": [] }""".stripMargin
 
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                responseString,
-                responseHeader
-              )
-            )
-          )
+        stubForGet(bulkPaymentUrl, OK, responseString)
 
-        doRetrieveBulkPaymentRequest { response =>
+        retrieveBulkPaymentRequest { response =>
           response mustBe GetBulkPaymentNotFoundResponse
         }
       }
+
       "the DES response has no id number or financial transactions field" in {
         val responseString =
-          """{
-            | "processingDate": "2017-03-07T09:30:00.000Z"
-            |}""".stripMargin
+          """{ "processingDate": "2017-03-07T09:30:00.000Z" }""".stripMargin
 
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                responseString,
-                responseHeader
-              )
-            )
-          )
+        stubForGet(bulkPaymentUrl, OK, responseString)
 
-        doRetrieveBulkPaymentRequest { response =>
+        retrieveBulkPaymentRequest { response =>
           response mustBe GetBulkPaymentNotFoundResponse
         }
       }
     }
-
   }
 
   "Retrieve Account endpoint" must {
-
     "return a unavailable response" when {
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-
-        doRetrieveAccountRequest { response =>
+        stubForGet(getAccountUrl, SERVICE_UNAVAILABLE, "")
+        retrieveAccountRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
@@ -1505,54 +854,27 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a failure response" when {
       "the DES response is a failure response" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                """{
-                  | "code": "ERROR_CODE",
-                  | "reason" : "ERROR MESSAGE"
-                  }""".stripMargin,
-                responseHeader
-              )
-            )
-          )
+        stubForGet(
+          getAccountUrl,
+          OK,
+          """{ "code": "ERROR_CODE", "reason" : "ERROR MESSAGE" }""".stripMargin
+        )
 
-        doRetrieveAccountRequest { response =>
+        retrieveAccountRequest { response =>
           response mustBe DesFailureResponse("ERROR_CODE", "ERROR MESSAGE")
         }
       }
-      "the DES response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                ""
-              )
-            )
-          )
 
-        doRetrieveAccountRequest { response =>
+      "the DES response has no json body" in {
+        stubForGet(getAccountUrl, OK, "")
+        retrieveAccountRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
+
       "the DES response is missing required fields" in {
-        val responseString = "{}"
-
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                responseString,
-                responseHeader
-              )
-            )
-          )
-
-        doRetrieveAccountRequest { response =>
+        stubForGet(getAccountUrl, OK, "{}")
+        retrieveAccountRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
@@ -1562,33 +884,24 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
       "the DES response is the appropriate json response" in {
         val responseString =
           """{
-            |  "investorId": "1234567890",
-            |  "status": "OPEN",
-            |  "creationDate": "2016-01-01",
-            |  "creationReason": "REINSTATED",
-            |  "hmrcClosureDate": "2016-02-01",
-            |  "accountClosureReason": "TRANSFERRED_OUT",
-            |  "transferInDate": "2016-03-01",
-            |  "transferOutDate": "2016-04-01",
-            |  "xferredFromAccountId": "123abc789ABC34567890",
-            |  "xferredFromLmrn": "Z123453",
-            |  "lisaManagerClosureDate": "2016-05-01",
-            |  "subscriptionStatus": "AVAILABLE",
-            |  "firstSubscriptionDate": "2016-01-06"
+            | "investorId": "1234567890",
+            | "status": "OPEN",
+            | "creationDate": "2016-01-01",
+            | "creationReason": "REINSTATED",
+            | "hmrcClosureDate": "2016-02-01",
+            | "accountClosureReason": "TRANSFERRED_OUT",
+            | "transferInDate": "2016-03-01",
+            | "transferOutDate": "2016-04-01",
+            | "xferredFromAccountId": "123abc789ABC34567890",
+            | "xferredFromLmrn": "Z123453",
+            | "lisaManagerClosureDate": "2016-05-01",
+            | "subscriptionStatus": "AVAILABLE",
+            | "firstSubscriptionDate": "2016-01-06"
             |}""".stripMargin
 
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                responseString,
-                responseHeader
-              )
-            )
-          )
+        stubForGet(getAccountUrl, OK, responseString)
 
-        doRetrieveAccountRequest { response =>
+        retrieveAccountRequest { response =>
           response mustBe GetLisaAccountSuccessResponse(
             accountId = "123456",
             investorId = "1234567890",
@@ -1614,32 +927,23 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
       "there is no subscriptionStatus in the json response from DES" in {
         val responseString =
           """{
-            |  "investorId": "1234567890",
-            |  "status": "OPEN",
-            |  "creationDate": "2016-01-01",
-            |  "creationReason": "REINSTATED",
-            |  "hmrcClosureDate": "2016-02-01",
-            |  "accountClosureReason": "TRANSFERRED_OUT",
-            |  "transferInDate": "2016-03-01",
-            |  "transferOutDate": "2016-04-01",
-            |  "xferredFromAccountId": "123abc789ABC34567890",
-            |  "xferredFromLmrn": "Z123453",
-            |  "lisaManagerClosureDate": "2016-05-01",
-            |  "firstSubscriptionDate": "2016-01-06"
+            | "investorId": "1234567890",
+            | "status": "OPEN",
+            | "creationDate": "2016-01-01",
+            | "creationReason": "REINSTATED",
+            | "hmrcClosureDate": "2016-02-01",
+            | "accountClosureReason": "TRANSFERRED_OUT",
+            | "transferInDate": "2016-03-01",
+            | "transferOutDate": "2016-04-01",
+            | "xferredFromAccountId": "123abc789ABC34567890",
+            | "xferredFromLmrn": "Z123453",
+            | "lisaManagerClosureDate": "2016-05-01",
+            | "firstSubscriptionDate": "2016-01-06"
             |}""".stripMargin
 
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                OK,
-                responseString,
-                responseHeader
-              )
-            )
-          )
+        stubForGet(getAccountUrl, OK, responseString)
 
-        doRetrieveAccountRequest { response =>
+        retrieveAccountRequest { response =>
           response mustBe GetLisaAccountSuccessResponse(
             accountId = "123456",
             investorId = "1234567890",
@@ -1663,54 +967,31 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
   }
 
   "Report withdrawal endpoint" must {
-    "uses the des writes when posting data" in {
-      when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-        .thenReturn(
-          Future.successful(
-            HttpResponse(
-              CREATED,
-              s"""{"transactionID": "87654321","message": "On Time"}""",
-              responseHeader
-            )
-          )
-        )
-      doReportWithdrawalRequest { _ =>
-        verify(mockHttp).post(any())(any())
+    "post to the withdrawal endpoint" in {
+      stubForPost(withdrawalUrl, CREATED, """{"transactionID": "87654321","message": "On Time"}""")
+      reportWithdrawalRequest { _ =>
+        server.verify(postRequestedFor(urlEqualTo(withdrawalUrl)))
       }
     }
 
     "return a populated DesTransactionResponse" when {
       "the DES response has a json body that is in the correct format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                s"""{"transactionID": "87654321","message": "On Time"}""",
-                responseHeader
-              )
-            )
-          )
-        doReportWithdrawalRequest { response =>
+        stubForPost(withdrawalUrl, CREATED, """{"transactionID": "87654321","message": "On Time"}""")
+        reportWithdrawalRequest { response =>
           response mustBe DesTransactionResponse("87654321", Some("On Time"))
         }
       }
-
     }
 
     "return a populated DesTransactionExistResponse" when {
       "the DES response has status CONFLICT" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CONFLICT,
-                s"""{"code": "WITHDRAWAL_CHARGE_ALREADY_EXISTS","reason": "A withdrawal charge with these details has already been requested for this investor","investorTransactionID":"2345678901"}""",
-                responseHeader
-              )
-            )
-          )
-        doReportWithdrawalRequest { response =>
+        stubForPost(
+          withdrawalUrl,
+          CONFLICT,
+          """{"code": "WITHDRAWAL_CHARGE_ALREADY_EXISTS","reason": "A withdrawal charge with these details has already been requested for this investor","investorTransactionID":"2345678901"}"""
+        )
+
+        reportWithdrawalRequest { response =>
           response mustBe DesWithdrawalChargeAlreadyExistsResponse(
             "WITHDRAWAL_CHARGE_ALREADY_EXISTS",
             "A withdrawal charge with these details has already been requested for this investor",
@@ -1720,17 +1001,13 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
       }
 
       "the DES response has status FORBIDDEN and a transactionID value in the json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                FORBIDDEN,
-                s"""{"code": "SUPERSEDED_TRANSACTION_ID_ALREADY_SUPERSEDED","reason": "This withdrawal charge has already been superseded","supersededTransactionByID": "2345678901"}""",
-                responseHeader
-              )
-            )
-          )
-        doReportWithdrawalRequest { response =>
+        stubForPost(
+          withdrawalUrl,
+          FORBIDDEN,
+          """{"code": "SUPERSEDED_TRANSACTION_ID_ALREADY_SUPERSEDED","reason": "This withdrawal charge has already been superseded","supersededTransactionByID": "2345678901"}"""
+        )
+
+        reportWithdrawalRequest { response =>
           response mustBe DesWithdrawalChargeAlreadySupersededResponse(
             "SUPERSEDED_TRANSACTION_ID_ALREADY_SUPERSEDED",
             "This withdrawal charge has already been superseded",
@@ -1742,86 +1019,52 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return the default DesFailureResponse" when {
       "the DES response has no json body" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                GATEWAY_TIMEOUT,
-                ""
-              )
-            )
-          )
-        doReportWithdrawalRequest { response =>
+        stubForPost(withdrawalUrl, OK, "")
+        reportWithdrawalRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
 
       "the DES response has a json body that is in an incorrect format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                """[1,2,3]"""
-              )
-            )
-          )
-        doReportWithdrawalRequest { response =>
+        stubForPost(withdrawalUrl, CREATED, """[1,2,3]""")
+        reportWithdrawalRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
 
       "the DES response has a html body instead of JSON format" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                CREATED,
-                """<!DOCTYPE html>"""
-              )
-            )
-          )
-        doReportWithdrawalRequest { response =>
+        server.stubFor(
+          post(urlEqualTo(withdrawalUrl))
+            .willReturn(aResponse().withStatus(CREATED).withBody("<!DOCTYPE html>"))
+        )
+
+        reportWithdrawalRequest { response =>
           response mustBe DesFailureResponse()
         }
       }
-
     }
 
     "return a specific DesFailureResponse" when {
       "a specific failure is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                NOT_FOUND,
-                s"""{"code": "LIFE_EVENT_DOES_NOT_EXIST","reason": "The lifeEventId does not match with HMRC’s records."}""",
-                responseHeader
-              )
-            )
-          )
-        doReportWithdrawalRequest { response =>
+        stubForPost(
+          withdrawalUrl,
+          NOT_FOUND,
+          """{"code": "LIFE_EVENT_DOES_NOT_EXIST","reason": "The lifeEventId does not match with HMRC’s records."}"""
+        )
+
+        reportWithdrawalRequest { response =>
           response mustBe DesFailureResponse(
             "LIFE_EVENT_DOES_NOT_EXIST",
             "The lifeEventId does not match with HMRC’s records."
           )
         }
       }
-
     }
 
     "return a DesUnavailableResponse" when {
       "a 503 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                SERVICE_UNAVAILABLE,
-                ""
-              )
-            )
-          )
-        doReportWithdrawalRequest { response =>
+        stubForPost(withdrawalUrl, SERVICE_UNAVAILABLE, "")
+        reportWithdrawalRequest { response =>
           response mustBe DesUnavailableResponse
         }
       }
@@ -1829,16 +1072,8 @@ class DesConnectorSpec extends DesConnectorTestHelper with BeforeAndAfterEach {
 
     "return a DesBadRequestResponse" when {
       "a 400 is returned" in {
-        when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-          .thenReturn(
-            Future.successful(
-              HttpResponse(
-                BAD_REQUEST,
-                ""
-              )
-            )
-          )
-        doReportWithdrawalRequest { response =>
+        stubForPost(withdrawalUrl, BAD_REQUEST, "")
+        reportWithdrawalRequest { response =>
           response mustBe DesBadRequestResponse
         }
       }

--- a/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorSpec.scala
@@ -1125,7 +1125,7 @@ class DesConnectorSpec extends DesConnectorTestHelper {
       val result = desConnector.correlationId
 
       result must startWith("abcd1234-ab12-cd34-ef56-")
-      UUID.fromString(result)
+      UUID.fromString(result) // throws if invalid UUID
     }
 
     "make a new, valid UUID when the requestId does not match the correlation id pattern" in {

--- a/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorTestHelper.scala
+++ b/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorTestHelper.scala
@@ -16,45 +16,37 @@
 
 package uk.gov.hmrc.lisaapi.connectors
 
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.lisaapi.connectors.DesConnector
-import uk.gov.hmrc.lisaapi.helpers.BaseTestFixture
 import uk.gov.hmrc.lisaapi.models._
 import uk.gov.hmrc.lisaapi.models.des.{DesFailure, DesResponse}
 
 import java.time.LocalDate
 import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.io.Source
 
-trait DesConnectorTestHelper extends BaseTestFixture with GuiceOneAppPerSuite {
+trait DesConnectorTestHelper extends ConnectorSpecHelper {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
   val validBonusPaymentResponseJson: String =
     Source.fromInputStream(getClass.getResourceAsStream("/json/request.valid.bonus-payment-response.json")).mkString
 
-  val responseHeader: Map[String, List[String]] = Map("Content-Type" -> List("application/json"))
+  lazy val desConnector: DesConnector = injector.instanceOf[DesConnector] // lazy to allow wiremock to start
 
-  val desConnector: DesConnector = new DesConnector(mockHttp, mockAppContext)
-
-  def doCreateInvestorRequest(callback: DesResponse => Unit): Unit = {
+  def createInvestorRequest(callback: DesResponse => Unit): Unit = {
     val request  = CreateLisaInvestorRequest("AB123456A", "A", "B", LocalDate.parse("2000-01-01"))
     val response = Await.result(desConnector.createInvestor("Z019283", request), Duration.Inf)
-
     callback(response)
   }
 
-  def doCreateAccountRequest(callback: DesResponse => Unit): Unit = {
+  def createAccountRequest(callback: DesResponse => Unit): Unit = {
     val request  = CreateLisaAccountCreationRequest("1234567890", "9876543210", LocalDate.parse("2000-01-01"))
     val response = Await.result(desConnector.createAccount("Z019283", request), Duration.Inf)
-
     callback(response)
   }
 
-  def doTransferAccountRequest(callback: DesResponse => Unit): Unit = {
+  def transferAccountRequest(callback: DesResponse => Unit): Unit = {
     val transferAccount = AccountTransfer("1234", "1234", LocalDate.parse("2000-01-01"))
     val request         = CreateLisaAccountTransferRequest(
       "Transferred",
@@ -63,45 +55,40 @@ trait DesConnectorTestHelper extends BaseTestFixture with GuiceOneAppPerSuite {
       LocalDate.parse("2000-01-01"),
       transferAccount
     )
-    val response        = Await.result(desConnector.transferAccount("Z019283", request), Duration.Inf)
 
+    val response = Await.result(desConnector.transferAccount("Z019283", request), Duration.Inf)
     callback(response)
   }
 
-  def doCloseAccountRequest(callback: DesResponse => Unit): Unit = {
+  def closeAccountRequest(callback: DesResponse => Unit): Unit = {
     val request  = CloseLisaAccountRequest("All funds withdrawn", LocalDate.parse("2000-01-01"))
     val response = Await.result(desConnector.closeAccount("Z123456", "ABC12345", request), Duration.Inf)
-
     callback(response)
   }
 
-  def doReinstateAccountRequest(callback: DesResponse => Unit): Unit = {
+  def reinstateAccountRequest(callback: DesResponse => Unit): Unit = {
     val response = Await.result(desConnector.reinstateAccount("Z123456", "ABC12345"), Duration.Inf)
-
     callback(response)
   }
 
   def updateFirstSubscriptionDateRequest(callback: DesResponse => Unit): Unit = {
     val request  = UpdateSubscriptionRequest(LocalDate.parse("2000-01-01"))
     val response = Await.result(desConnector.updateFirstSubDate("Z019283", "123456789", request), Duration.Inf)
-
     callback(response)
   }
 
-  def doReportLifeEventRequest(callback: DesResponse => Unit): Unit = {
+  def reportLifeEventRequest(callback: DesResponse => Unit): Unit = {
     val request  = ReportLifeEventRequest("LISA Investor Terminal Ill Health", LocalDate.parse("2000-01-01"))
     val response = Await.result(desConnector.reportLifeEvent("Z123456", "ABC12345", request), Duration.Inf)
-
     callback(response)
   }
 
-  def doRetrieveLifeEventRequest(callback: Either[DesFailure, Seq[GetLifeEventItem]] => Unit): Unit = {
+  def retrieveLifeEventRequest(callback: Either[DesFailure, Seq[GetLifeEventItem]] => Unit): Unit = {
     val response = Await.result(desConnector.getLifeEvent("Z123456", "ABC12345", "1234567890"), Duration.Inf)
-
     callback(response)
   }
 
-  def doRequestBonusPaymentRequest(callback: DesResponse => Unit): Unit = {
+  def requestBonusPaymentRequest(callback: DesResponse => Unit): Unit = {
     val request = RequestBonusPaymentRequest(
       lifeEventId = Some("1234567891"),
       periodStartDate = LocalDate.parse("2017-04-06"),
@@ -112,23 +99,20 @@ trait DesConnectorTestHelper extends BaseTestFixture with GuiceOneAppPerSuite {
     )
 
     val response = Await.result(desConnector.requestBonusPayment("Z123456", "ABC12345", request), Duration.Inf)
-
     callback(response)
   }
 
-  def doRetrieveBonusPaymentRequest(callback: DesResponse => Unit): Unit = {
+  def retrieveBonusPaymentRequest(callback: DesResponse => Unit): Unit = {
     val response = Await.result(desConnector.getBonusOrWithdrawal("Z123456", "ABC12345", "123456"), Duration.Inf)
-
     callback(response)
   }
 
-  def doRetrieveTransactionRequest(callback: DesResponse => Unit): Unit = {
+  def retrieveTransactionRequest(callback: DesResponse => Unit): Unit = {
     val response = Await.result(desConnector.getTransaction("Z123456", "ABC12345", "123456"), Duration.Inf)
-
     callback(response)
   }
 
-  def doRetrieveBulkPaymentRequest(callback: DesResponse => Unit): Unit = {
+  def retrieveBulkPaymentRequest(callback: DesResponse => Unit): Unit = {
     val response = Await.result(
       desConnector.getBulkPayment("Z123456", LocalDate.parse("2018-01-01"), LocalDate.parse("2018-01-01")),
       Duration.Inf
@@ -137,13 +121,12 @@ trait DesConnectorTestHelper extends BaseTestFixture with GuiceOneAppPerSuite {
     callback(response)
   }
 
-  def doRetrieveAccountRequest(callback: DesResponse => Unit): Unit = {
+  def retrieveAccountRequest(callback: DesResponse => Unit): Unit = {
     val response = Await.result(desConnector.getAccountInformation("Z123456", "123456"), Duration.Inf)
-
     callback(response)
   }
 
-  def doReportWithdrawalRequest(callback: DesResponse => Unit): Unit = {
+  def reportWithdrawalRequest(callback: DesResponse => Unit): Unit = {
     val request = SupersededWithdrawalChargeRequest(
       Some(250.00),
       LocalDate.parse("2017-12-06"),
@@ -164,7 +147,6 @@ trait DesConnectorTestHelper extends BaseTestFixture with GuiceOneAppPerSuite {
     )
 
     val response = Await.result(desConnector.reportWithdrawalCharge("Z123456", "ABC12345", request), Duration.Inf)
-
     callback(response)
   }
 

--- a/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorTestHelper.scala
+++ b/test/uk/gov/hmrc/lisaapi/connectors/DesConnectorTestHelper.scala
@@ -17,7 +17,8 @@
 package uk.gov.hmrc.lisaapi.connectors
 
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.lisaapi.models._
+import uk.gov.hmrc.lisaapi.helpers.ConnectorSpecHelper
+import uk.gov.hmrc.lisaapi.models.*
 import uk.gov.hmrc.lisaapi.models.des.{DesFailure, DesResponse}
 
 import java.time.LocalDate

--- a/test/uk/gov/hmrc/lisaapi/helpers/BaseTestFixture.scala
+++ b/test/uk/gov/hmrc/lisaapi/helpers/BaseTestFixture.scala
@@ -19,12 +19,9 @@ package uk.gov.hmrc.lisaapi.helpers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.Configuration
-import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.lisaapi.config.AppContext
 
 trait BaseTestFixture extends PlaySpec with MockitoSugar {
-
   val mockConfiguration: Configuration = mock[Configuration]
   val mockAppContext: AppContext       = mock[AppContext]
-  val mockHttp: HttpClientV2           = mock[HttpClientV2]
 }

--- a/test/uk/gov/hmrc/lisaapi/helpers/ConnectorSpecHelper.scala
+++ b/test/uk/gov/hmrc/lisaapi/helpers/ConnectorSpecHelper.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.lisaapi.connectors
+package uk.gov.hmrc.lisaapi.helpers
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock.*

--- a/test/uk/gov/hmrc/lisaapi/helpers/ServiceTestFixture.scala
+++ b/test/uk/gov/hmrc/lisaapi/helpers/ServiceTestFixture.scala
@@ -21,7 +21,6 @@ import uk.gov.hmrc.lisaapi.connectors.DesConnector
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 
 trait ServiceTestFixture extends BaseTestFixture with GuiceOneAppPerSuite {
-
   val mockDesConnector: DesConnector     = mock[DesConnector]
   val mockAuditConnector: AuditConnector = mock[AuditConnector]
 }

--- a/test/uk/gov/hmrc/lisaapi/utils/WireMockHelper.scala
+++ b/test/uk/gov/hmrc/lisaapi/utils/WireMockHelper.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.lisaapi.utils
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
+
+trait WireMockHelper extends BeforeAndAfterAll with BeforeAndAfterEach { this: Suite =>
+
+  protected val server: WireMockServer = new WireMockServer(wireMockConfig().dynamicPort())
+
+  override def beforeAll(): Unit = {
+    server.start()
+    super.beforeAll()
+  }
+
+  override def beforeEach(): Unit = {
+    server.resetAll()
+    super.beforeEach()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    server.stop()
+  }
+}

--- a/test/uk/gov/hmrc/lisaapi/utils/WireMockHelper.scala
+++ b/test/uk/gov/hmrc/lisaapi/utils/WireMockHelper.scala
@@ -38,4 +38,5 @@ trait WireMockHelper extends BeforeAndAfterAll with BeforeAndAfterEach { this: S
     super.afterAll()
     server.stop()
   }
+
 }


### PR DESCRIPTION
- Removed `UpstreamErrorResponse` from one of the methods in the connector, as this code was unreachable with the `readRaw` import.

- Explicit tests for correlationId method

 - Removed some boilerplate from the tests
 
 -  Added a couple of tests to increase coverage percentage.